### PR TITLE
Update nokogiri to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     minitest (5.10.3)
     multipart-post (2.0.0)
     netrc (0.11.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
# What does this do?

`bundle update nokogiri`

# Why was this needed?

In response to security advisory reported by bundler audit:

```
Name: nokogiri
Version: 1.8.1
Advisory: CVE-2017-15412
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1714
Title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
Solution: upgrade to >= 1.8.2

Vulnerabilities found!
```

# Relevant Issue(s)

# Implementation notes

# Screenshots

# Notes to Reviewer

# Notes to Merger

