### PR TITLE
Add Travis badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Legislative Explorer
+# Legislative Explorer [![Build Status](https://travis-ci.org/everypolitician/legislative-explorer.svg?branch=master)](https://travis-ci.org/everypolitician/legislative-explorer)
 
 This is a very rough and ready prototype for investigating legislative
 information in Wikidata.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Legislative Explorer
+
 This is a very rough and ready prototype for investigating legislative
 information in Wikidata.
 

--- a/README.md
+++ b/README.md
@@ -11,5 +11,3 @@ https://github.com/everypolitician/viewer-sinatra
 
 This is a sinatra app, and should run using any `foreman`-like manager.
 (Though only tested with https://github.com/chrismytton/shoreman)
-
-


### PR DESCRIPTION
# What does this do?

Adds a title to the readme and puts a Travis badge next to it.

# Why was this needed?

I wanted to get to the Travis page for this repository quickly and the first place I always check is the readme. It will also help people see the current status of the build (always green, right?! 😄).

# Relevant Issue(s)

# Implementation notes

# Screenshots

# Notes to Reviewer

Ironically the build has failed on this PR but that's because of the issue addressed in #11.

# Notes to Merger

