### PR TITLE
Speed up tests and isolate them from Wikidata changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ group :test do
   gem 'minitest'
   gem 'pry'
   gem 'rack-test'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 group :quality do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     domain_name (0.5.20170404)
@@ -44,6 +46,7 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
+    hashdiff (0.3.7)
     html_validation (1.1.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -103,6 +106,7 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
+    safe_yaml (1.0.4)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -123,11 +127,16 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
+    vcr (4.0.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webmock (3.3.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     yajl-ruby (1.3.1)
     yard (0.9.12)
 
@@ -158,6 +167,8 @@ DEPENDENCIES
   rubocop
   sass
   sinatra
+  vcr
+  webmock
   yajl-ruby
   yard
 

--- a/t/fixtures/vcr/Bicameral_legislature.yml
+++ b/t/fixtures/vcr/Bicameral_legislature.yml
@@ -1,0 +1,224 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q11010%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:21:30 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '224'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 14401168, 71276487
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2025 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA71SQY6CQBC884rJnInEiHHhDV48mz00Swc6tiOZaWSN4e87
+        MARZ41VPk6ru6qpK5h4ppWuEUqtc3T3w8ArWDfCoNDnQ8fjsoUDW6tuv9PEg
+        suhaFrfQFWRKMtWkDaQKN+alkZFbgwOlW0s6fvBX4DYMapEmT5Ku61YdnagE
+        gdXFVgkaIbklh812l2Z6UvbxwmrK+c/v98w5g6nG02iWlnMUJkEL/DpOA5YJ
+        zt599oyC83trrr+yNN1+rmdBP76lHyvGihyDtBafKocvEPV/3BrfOzoCAAA=
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:21:30 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q11010%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:24:54 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '279'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 79856938, 73500388
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2018 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72TwW6DMAyG730KK2dUitRdeIXtsB16mnZwmwy8hYASU4oq
+        3n0BCiPrtF22nuLfdvJ/cpLzCkDkCqWAFM5eeHlE63r5DEKrjJxGrq0SUSAf
+        cK90n3urLTlJB6bSfNVz06GsDdt2Ec4lp5BdH1RoeVrHKrx4oC7qEa1ytWa3
+        oNyTkWSyC+mYhJB4bh4q3FZDSnhAEX3mj6jrsZAzV2kcN02zbuidJDKuS5vF
+        yjBxGz8lySbZiMvObjoinMCfe27vrh2ncd7E7OrSQ9dToVONJhsMlFkaz0Ca
+        WFnU30M9otWEhWeA8hU4V7Azvl/Cvb9eWRY/D/xfkH4DCN7wbbyHtRt/xKr7
+        AAY/M163AwAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:24:55 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q11010%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:24:56 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 123490405, 70237381
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA8VSsQ6CMBTc+YqXzgRkMCasLg4szsbhESo0lpa0D5AQ/l2g
+        BNE469TcvXfv7pL2HgArOGYMYuhHMMIGjZ3gBViFhpjv3gRTLhlcx6XBn2SG
+        21qS3ShToTKh8kXtSFiurFszRV3FJ4rVRjD/xTcoazcoiKo4DNu2DVpxFxkS
+        BtrkIVckqAvPUbTbHdiiHPyt15L0zfBRyliiyufbXG091yxSEDcov+c56dpy
+        0DdItMnsauw5+x+U3f+j7FGXpVafdd0n8IYnuVtaQj4CAAA=
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:24:56 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/Estonia_Page.yml
+++ b/t/fixtures/vcr/Estonia_Page.yml
@@ -1,0 +1,238 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q191%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 03:47:39 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '408'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 87257820, 60773359 67300975
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '101'
+      X-Cache:
+      - cp2006 miss, cp2018 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7VUy27CMBC88xVWekUEk0IK96pSBVJLL5WqHkxYwgrHjhyb
+        gFD+rLf+WPOgeZS0UqVwsme93pm1xz71CLG2wNYWmZFTClK4ZyrK4BuxPGmE
+        VkerX07nbAU8w6EMDWcapcgQHMAzGvfQAGUyBx+jNNso+AHLlFzEeSyDcrNB
+        D6pZsUDeU6FJP5OuIDJcRzX1KxRrFP65gyJIqk7KxDyqjyFkIcsotPpVfM+4
+        KRa2Wocz247jeBDjDtdMs4FUvg1Coz7az3RKrfO+5LtA/WyafNn2krNe2smL
+        joZDar8u5i/eFgJ2swYPA8brwsrNHDWo5lolmjp0PHHGl8Lq99D1SYyo606n
+        l5yVNTpnvB3R8V0LZdPQXbFN0g6d4SXb2aRd87mOS2nLHTYeYpP0EPAZZ8LP
+        64P4v3HuIy0Fsj8u8Sq0D3IPSgRp50RuiN4CWUJoVhy9DP8q6uIb6VjWEtHH
+        nfRNu8Ouwvn4+aGQLFMzRL857Sq8TwoDIAsUGKVZbceej0nx9/aSL7qpls45
+        BgAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 03:47:39 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q191%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 03:47:40 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '562'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 206205279, 68960146 60089160
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '101'
+      X-Cache:
+      - cp2012 miss, cp2018 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA82YzXLaMBDH7zyFx7nSIFnyF9dc0g6daZMO05lODxusGFFh
+        e4QMZTK8SY+8Ak/gF6uNGcckOfTQLDqZXSTvX/rtemU/DRzHnQtIXGfsPNVG
+        ba5Brxrzh+NKI5busL1O4EGoxijyolRgZJ41Vv74KGfi+Vc37HjX07VzKpHK
+        VT251OKF2Q5xftYadsNGlRarUplVT9iDzBKZpSdxrdM5iexGHV1mW4jG5ZZa
+        usNn/xpU2f4xN6YYj0abzeZ6I3/JBAxc5zodicxIsx19pRHxCHFPU3fDfrCT
+        1LOIv5dqrCBLjzcXWT9oJ0bVkzWotwXdgl6Uzk1eZmb7Omxvz8/jNsK7AP1F
+        seNy6jXQ0ffPk/vZXCzhKhEzuTxX8G/q/NAPCH2t6zx1/tPeRySMuR+9He1d
+        Nr/6o5Rw7mABq9rXBR604d871WKPhZip9g20sTfVqE9ZGGIziOI4YIgMPibw
+        YSq1xRh46Mf4GHzCAkQMX6q9zuyFEHmMxxcoBd9DZDCp9tU+E3aXgx8TFuM3
+        BhJQRBJTqRZQn7GspcBDQskF2jNqPdxBocBaBIzz3hMaB4FHmBdiIrgH0MJe
+        BIwR/M5cn8oxO/O0OljcDhijvYTEa8whR0TwqTqkYm3xo4hEnF6gDoIIFcJe
+        W82Akguci1iA2Q6moFJ7EXhxzDk6AhpRhvqidlAWl4EXchZhM+BBwFHr4FZK
+        i9+V/ehlR26/Jg92fwGQxVgr5hYAAA==
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 03:47:40 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q191%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 03:47:41 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '324'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 206584547, 58161013 71635896
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '100'
+      X-Cache:
+      - cp2012 miss, cp2018 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7WTPW+DMBCG9/wKy11RMAWCxNY9Hap2qFR1uICBU41BxkBR
+        xH8vXyLQJFKGZDrew3fv47N93BBCEw4hJT45dqKTFaiil1+EouYpNca4hwMX
+        vcizvBSgMZO9yqIIA376mpcNXac4JwWPseiKS8X/yXEJ+e4YWqOnUrwohS4W
+        YAeUIcp4ghuTZIKcVw0p3eS8T9FSITVO+QpEOf5ItM5906zrelvjD4agYZup
+        2ORSo27MN8vzGJ0KW2NpNYGu/H5T4QuQ8dCay6XljCK6YgXiMs4HCIFSnjsu
+        hr227Inn3svd2MM+nhmzzM/X/XuQ8BSeQh5guja/Dcxxdsx1z7mmY7/32G3P
+        YS676veQ2afQZIpkEbl6COsHcq8btnOYbTnOZbsH3TKokLxAMXsOsR1f3ab9
+        Az9XQEgOBAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 03:47:42 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/Homepage.yml
+++ b/t/fixtures/vcr/Homepage.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?item%20?itemLabel%20WHERE%20%7B%0A%20%20?item%20p:P31%20?statement%20.%0A%20%20?statement%20ps:P31%20wd:Q160016%20.%0A%20%20MINUS%20%7B%20?statement%20pq:P582%20?end%20%7D%20%20%20%20%20%20%23%20no%20longer%20a%20country%0A%20%20MINUS%20%7B%20?item%20wdt:P1552%20wd:Q47185282%20%7D%20%23%20not%20free%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20?itemLabel%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 03:55:43 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '1706'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 126208967, 63909304
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA8WdS3LbRhCG9z4FSmvFIkESD+8sWZZkPUqRZC+c8qIJjIEJ
+        gRlmMEOadPk0WWWRU/hiASnFdlLZ5sNGFEGCwFfz6L97ugefn0XRQa2kPIhe
+        RJ/7N/3blbhu9/aX6EB71R4cPr5eyVw1B9GH/ktfDnenOdWFxnc/nDnXptSm
+        ejr78WD09CvfvrU/5DdLtTt0EJw+OPx+fCVNePyg9n754uhovV4/X+uFLsXL
+        c+uqI2W89pujn+M4Png678vhj1d6us9/XO5T27xoxFT7X1bmxyt+u5OmP9lJ
+        899387KZi9Hy7YrPHq/7vzNmJKMprXM0Y5qNUUavqyCRmDI6FjcPJc07HU9J
+        XlftLmxoykmeo5St4kfndISOztD5/sMBKGlIHDEfkabkuD+5kVJ1NW1NplMU
+        082ltB098ZDW5Fg1lQ4t3o4xy6i3ih6RCYtotKEJxylJWAcvNGI6I03HsW30
+        agCFPkMZu17m7MXruXJbVdkVL+3yZIIi+24tOOR4hrark61u6K47JiX6cWgq
+        GUDaJWg7BrfoB2T0WjpLd9gE5DzpByTuOI9H4zHKuFTRO+VKWvvEOelWntS6
+        oQnTCTnznNjGtnN+5klHKGRrHe5sZSOWsfMS3emCF3mk43zirPgBhCw6JjdL
+        Fzpc8JDC9WSrijq6U8swb3RBR0FI1fNKmVbcAl83IAflK9tqw888aZYMAGmG
+        6razlGzTU+l89KB7w4nrH7JVT4sgJc+YkxG80ya6l2Y1AOc4J52S085bfqEr
+        RddHXquy/9CrMrr3/UsX2Y/RtS6cNarj0ccouv5V00phgvKZ/vySHqLoeslr
+        J6bAYwYT0hE7U/218aE4ziYoo2vFbGhGdFXorOYD61PSXJ45pfCxmCY5izhA
+        LDZFhfpZ6HVAKw0fcR4lKKY2agDGFGf86Vh3nQTc7WI77YafXdOc1AHnor3G
+        IyKkCji3pgxO8EgluQJ0HkwlDlc6GWklLwo1gOORJGQ7XpiSXzWYxSzhIEGA
+        mLSQF26IrpqNSF1+0TlRdL7LBB2MXpoNL+VQxJV1m+jESudxD4uU5W+kFX7l
+        Bw0EvJElnh2ajUmp+sa6Ekcco6U+l8pscMuY52ihz6U2VWnb3ZKAr1V0o/q/
+        bmcuO3xdYIRiOz0X3NfK0EnoMqx7fxJHJN3Jy42rNtuOT8WP0dTJK/F8Jn6G
+        1gNfqbkYa/gU2AkK2VlfWx6SNJtXeq74vPTJNEUZVVF7ZTqv8EKnCQvq6zBA
+        of4EnXvCJ9XObXAVPzJJsXctpVTSFYLn9IziEcrZyBrXdmjixw5x0w2gCRIW
+        stQr1eGVpDELqfHkFrirej7Bjp1XXVdL00QX3RCucz+7pihtf6de49UGOTr1
+        qE+6sLhTibajbUq7wgNcaCXFtTWCN2OKxgZ6xMryu9jEaMp9D9l7W6pyvO+M
+        pg5cW2eLYgBI1FzarbRz/VtQuERH++xGdmVceFuimcs30mq+FDjJU5QxuIB3
+        VZRQLaXBc3mmKOE6eq9kiEQQVA3c6EKcVIHPekUjdje6UgPMrBMakZd1qPGw
+        bi10Uk82JVvxVhZ6gOXJJJ+hkA2ee56NpiihkZZXOWMUcRkk2tnJQcom0gk7
+        LPdGcoPXapF+1q3CZWuOesu3tW70ctn3VnxTVNKRvLUDyNYpakCs86HCXZA4
+        JifYv7cA2ZffS6HKATYeiMfk+Lyz7QCpA+MZOcnehW6ATRTQHUPvRRsfXWrv
+        u/1OqTdqpfH00GSEE1+Fgm/ZWYpzvtOm6K+/b9tdEvBjBfQAVjXJ2G7dWn7V
+        JEMJTW9pnDb8ggK6K8H9bmkIVw/TEdpblePj7H07xijjpqhV0yg+gwJ9ksO9
+        Vs5JdKWsUfjuRCyoqWRpHb57D5rwfN/YlSwG0PIzGHKARwIlGQq529nYmoHy
+        uOIZKg5s8HX08qPjSzEzdKfRR9DLfhbii/lIzKXgpQjZDG1Ip6MrMQs+NI36
+        nv19GmlxYYC25FqVCq+bQUfjWvvtYyUtv0yNgn793UYPtv36xz5+cOu+/mkK
+        vcSfb4XuKP8gZjtAZDNNSYHwUKvoWGpp8d2acnTx4cFWdHwkYRvS9l4YHsdE
+        x2NvMvt7KPdT0IOdC96i+RRt0WA0v+qAJs48BLdQG3xcxiji7n88akAivl24
+        3itR+P7UpP14a/Rub/WnnVRoUTviSb/vIv+yVQOED1JyieytCwMkCiXoY0re
+        iQni8VyhGWlP3ssQjyxDVdB73c5lvv73bBt9eLb7/8tfPQBv7JqCAAA=
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 03:55:43 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/Lower_legislature.yml
+++ b/t/fixtures/vcr/Lower_legislature.yml
@@ -1,0 +1,222 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q11005%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:21:33 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '318'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 78834857, 60548116
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2018 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA71Ty07DMBC89yssc42aBCiHXLkgUQ4IISEhDm7sJgY/InvT
+        EFX5d5xnYwpISNCTPTvencnY2S8QwjkjFKME7R1wcEeMbeEzwoJl3AoCpWE4
+        8OCabJhoa6+l4ZbyFLhWn/F0KNWlAlPPthNlGQHbbgpiYFx7Fr04Q03QWjTM
+        lgLszOWGK8pVNjjti8h3PB3uGKiLroSdQRwc6jsiyp7IAYokDKuqWlb8jVMC
+        ZKlNFjIFHOrwPo6jaIWHzmYcMXyBL9b2ToLzuRfdxPMoisOnu/VDmjNJzihL
+        uSRi7mpqFhyY8bmD46tVdOzHu5E/z+DyiwTG6z2J2NEj9FXfpUgEUVknwNTv
+        M73RpWVIb9G1llIr+3PA/2LhUTmWolv3vqmW3+Z9Su1ubfo/ctF8AKTsXq83
+        BAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:21:33 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q11005%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:21:35 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '90'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 128589420, 71541141
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6vmUlBQykhNTFFSsFKoBnKA3LLEomIQN1pBqSCxqERJB0L7
+        JCal5igpxAIV1eqAtBWlFpfmlBQj6UzKzEvJzEuH6gar5KoFAOnNvQVjAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:21:35 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q11005%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:24:53 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '196'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 128142625, 60028570
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA21QQQrCMBC89xUh59CAImrf4MWzeNjSpQ3GVJJNYyn5u21T
+        agVPw8zu7Aw7ZIzxBqHirGDDSEbagXUTvTGuHHAxwwVK1Jzdx5UoJpNF5zW5
+        ja9UplKmXrxJZOnGujQr1L9wkri3iouv3oH2adAQvQopQwh5UA9VAUHe2lqi
+        IUW9vO6Ph/PuxBdrFJuspehP4PupCw2mnm+j2WauXbQitKD/99FtQMua1jtc
+        Q2eM6SNZ/ADbT2LgSQEAAA==
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:24:53 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/Unicameral_legislature.yml
+++ b/t/fixtures/vcr/Unicameral_legislature.yml
@@ -1,0 +1,221 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q217799%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:21:31 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '202'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 78344441, 71276491
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2018 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA21QywqDQAy8+xXLnkWlhQp+Qy89lx5iDRoat2U3qxXx3+sL
+        a6GnMDOZzJA+UEpXCIVWmepHMMIGrJvgVWlyoMN5nCFH1uo2rgzhZLLoPIvb
+        +XIyBZly9S6kWm5sSzMj3QsnSntLOvzyDbBfhErklcVx27ZRSw8qQCB62jJG
+        IyRdfDmmSXI4pYlezUO4S1ur/kS+a84YTDlfR7NP3dowCVrg/428oTvUk64Y
+        S3IM4i1u+fMclvcEwwdEyI5gVgEAAA==
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:21:31 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q217799%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:24:57 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '306'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 123490465, 61952140
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA71TPU/DMBDd+ysss0ZNUoYq2dnKACxIiOGaWMlRx4nsc0NU
+        5b+T7yYUkJCgk+/d8917PtunFWM8FRBzFrJTAxp4BG1a+MK4FAkaCWS14M4C
+        7mAvZJt7sxpNjBFhrj7jaVOUW0W6moUTZQSQaYMCNI1rz7LXxlDttBa1MFaS
+        mbnco4pRJYPTPsmWjqfNHUNV0aV4Y5A75/wRpO2JlKgIXbcsy3WJB4yBYJ3r
+        xBWKkCr3YeNvt0HAh9J67DEcYanWFk+K88a3XcuN5/nu8/3uKUpFBjexiDAD
+        Obc1FUskoZfc2bLv+Zd+Flfy10Pwgy8Ux/u9itjFK1yqvmcylKCSTkCo38/0
+        ETHBQ57Ynyf7L9p3hnKF8O2EryLarXX/+1b1By9eNcAjBAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:24:57 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q217799%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Feb 2018 04:24:58 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '90'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 13856521, 60045192
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2025 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=07-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        11 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=07-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 11 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6vmUlBQykhNTFFSsFKoBnKA3LLEomIQN1pBqSCxqERJB0L7
+        JCal5igpxAIV1eqAtBWlFpfmlBQj6UzKzEvJzEuH6gar5KoFAOnNvQVjAAAA
+    http_version: 
+  recorded_at: Wed, 07 Feb 2018 04:24:58 GMT
+recorded_with: VCR 4.0.0

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -11,7 +11,9 @@ def country_page(qid)
 end
 
 describe 'Estonia Page' do
-  subject { country_page('Q191') }
+  subject do
+    VCR.use_cassette('Estonia Page') { country_page('Q191') }
+  end
 
   describe 'Country data' do
     it 'should know its name' do

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -5,7 +5,9 @@ require 'test_helper'
 require_rel '../../lib'
 
 describe 'Homepage' do
-  subject { Page::Home.new(countries: Query::CountryList.new.data) }
+  subject do
+    VCR.use_cassette('Homepage') { Page::Home.new(countries: Query::CountryList.new.data) }
+  end
 
   describe 'countries' do
     it 'should include free countries' do

--- a/t/page/legislature.rb
+++ b/t/page/legislature.rb
@@ -4,6 +4,9 @@ require 'test_helper'
 require_relative '../../lib/page/legislature'
 
 describe 'Unicameral' do
+  before { VCR.insert_cassette('Unicameral legislature') }
+  after { VCR.eject_cassette }
+
   let(:page) { Page::Legislature.new(id: 'Q217799') }
   subject { page.legislature }
 
@@ -43,6 +46,9 @@ describe 'Unicameral' do
 end
 
 describe 'Bicameral' do
+  before { VCR.insert_cassette('Bicameral legislature') }
+  after { VCR.eject_cassette }
+
   let(:page) { Page::Legislature.new(id: 'Q11010') }
   subject { page.legislature }
 
@@ -83,6 +89,9 @@ describe 'Bicameral' do
 end
 
 describe 'Lower' do
+  before { VCR.insert_cassette('Lower legislature') }
+  after { VCR.eject_cassette }
+
   let(:page) { Page::Legislature.new(id: 'Q11005') }
   subject { page.legislature }
 

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -8,6 +8,12 @@ require 'pathname'
 require 'rack/test'
 require 'pry'
 require 'everypolitician'
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 't/fixtures/vcr'
+  c.hook_into :webmock
+end
 
 module Minitest
   class Spec


### PR DESCRIPTION
# What does this do?

Uses [VCR](https://github.com/vcr/vcr) to isolate tests from the network.

# Why was this needed?

The test suite took ~100s to run on my machine. It now takes < 1s.

Previously if data was updated in Wikidata say, a country's population, this would break the tests. Now we have VCR fixtures so this will only change when we record new interactions with the Wikidata API.

# Relevant Issue(s)

# Implementation notes

# Screenshots

# Notes to Reviewer

Tests are only failing due to issue fixed in #11.

# Notes to Merger

