### PR TITLE
Remove `pry` debugging from application files

### DIFF
--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require_rel '../sparql'
 
 module Page

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require_rel '../sparql'
 
 module Page

--- a/lib/page/legislature.rb
+++ b/lib/page/legislature.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require_rel '../sparql'
 
 module Page

--- a/lib/query/country_cities.rb
+++ b/lib/query/country_cities.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require_rel '../sparql'
 
 module Query

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require_rel '../sparql'
 
 module Query


### PR DESCRIPTION
# What does this do?

Removes the `requires 'pry'` lines from files in `lib`.

# Why was this needed?

In our Gemfile `pry` is only available in `:test` so these requires lines failed when the application was deployed in production.

This still allows us to use pry in test - it's in the test_helper or you can require it just before using it with `require 'pry'; binding.pry`.

# Relevant Issue(s)

#7

# Implementation notes

# Screenshots

# Notes to Reviewer

Tests [only failing](https://travis-ci.org/everypolitician/legislative-explorer/builds/338358617#L690) due to issue fixed in #11.

# Notes to Merger

Remember to update our Heroku deployment to exclude the test group again https://github.com/everypolitician/legislative-explorer/issues/7#issuecomment-363044444