### PR TITLE
Standardise VCR configuration using minitest-around

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem 'bundler-audit'
   gem 'html_validation'
   gem 'minitest'
+  gem 'minitest-around'
   gem 'pry'
   gem 'rack-test'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    minitest-around (0.4.1)
+      minitest (~> 5.0)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.8.2)
@@ -153,6 +155,7 @@ DEPENDENCIES
   iso_country_codes
   json
   minitest
+  minitest-around
   nokogiri (>= 1.6.7)
   octokit
   pry

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -11,9 +11,9 @@ def country_page(qid)
 end
 
 describe 'Estonia Page' do
-  subject do
-    VCR.use_cassette('Estonia Page') { country_page('Q191') }
-  end
+  around { |test| VCR.use_cassette('Estonia Page', &test) }
+
+  subject { country_page('Q191') }
 
   describe 'Country data' do
     it 'should know its name' do

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -5,9 +5,9 @@ require 'test_helper'
 require_rel '../../lib'
 
 describe 'Homepage' do
-  subject do
-    VCR.use_cassette('Homepage') { Page::Home.new(countries: Query::CountryList.new.data) }
-  end
+  around { |test| VCR.use_cassette('Homepage', &test) }
+
+  subject { Page::Home.new(countries: Query::CountryList.new.data) }
 
   describe 'countries' do
     it 'should include free countries' do

--- a/t/page/legislature.rb
+++ b/t/page/legislature.rb
@@ -4,8 +4,7 @@ require 'test_helper'
 require_relative '../../lib/page/legislature'
 
 describe 'Unicameral' do
-  before { VCR.insert_cassette('Unicameral legislature') }
-  after { VCR.eject_cassette }
+  around { |test| VCR.use_cassette('Unicameral legislature', &test) }
 
   let(:page) { Page::Legislature.new(id: 'Q217799') }
   subject { page.legislature }
@@ -46,8 +45,7 @@ describe 'Unicameral' do
 end
 
 describe 'Bicameral' do
-  before { VCR.insert_cassette('Bicameral legislature') }
-  after { VCR.eject_cassette }
+  around { |test| VCR.use_cassette('Bicameral legislature', &test) }
 
   let(:page) { Page::Legislature.new(id: 'Q11010') }
   subject { page.legislature }
@@ -89,8 +87,7 @@ describe 'Bicameral' do
 end
 
 describe 'Lower' do
-  before { VCR.insert_cassette('Lower legislature') }
-  after { VCR.eject_cassette }
+  around { |test| VCR.use_cassette('Lower legislature', &test) }
 
   let(:page) { Page::Legislature.new(id: 'Q11005') }
   subject { page.legislature }

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -3,6 +3,7 @@
 ENV['RACK_ENV'] = 'test'
 
 require 'minitest/autorun'
+require 'minitest/around'
 require 'nokogiri'
 require 'pathname'
 require 'rack/test'


### PR DESCRIPTION
Make all VCR configuration use `around` blocks for simplicity and
consistency.

(Per review comment on #13)