### PR TITLE
Add tests for classes in Query module

### DIFF
--- a/t/fixtures/vcr/CountryCities_Q191.yml
+++ b/t/fixtures/vcr/CountryCities_Q191.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q191%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Feb 2018 03:54:13 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '324'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 249739332, 72300847
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2012 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=08-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Mon,
+        12 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=08-Feb-2018;Path=/;HttpOnly;secure;Expires=Mon, 12 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7WTPW+DMBCG9/wKy11RMAWCxNY9Hap2qFR1uICBU41BxkBR
+        xH8vXyLQJFKGZDrew3fv47N93BBCEw4hJT45dqKTFaiil1+EouYpNca4hwMX
+        vcizvBSgMZO9yqIIA376mpcNXac4JwWPseiKS8X/yXEJ+e4YWqOnUrwohS4W
+        YAeUIcp4ghuTZIKcVw0p3eS8T9FSITVO+QpEOf5ItM5906zrelvjD4agYZup
+        2ORSo27MN8vzGJ0KW2NpNYGu/H5T4QuQ8dCay6XljCK6YgXiMs4HCIFSnjsu
+        hr227Inn3svd2MM+nhmzzM/X/XuQ8BSeQh5guja/Dcxxdsx1z7mmY7/32G3P
+        YS676veQ2afQZIpkEbl6COsHcq8btnOYbTnOZbsH3TKokLxAMXsOsR1f3ab9
+        Az9XQEgOBAAA
+    http_version: 
+  recorded_at: Thu, 08 Feb 2018 03:54:13 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryDivisions_Q191.yml
+++ b/t/fixtures/vcr/CountryDivisions_Q191.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q191%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Feb 2018 03:54:15 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '562'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 249987099, 63368146 72300718
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '144'
+      X-Cache:
+      - cp2012 miss, cp2018 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=08-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Mon,
+        12 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=08-Feb-2018;Path=/;HttpOnly;secure;Expires=Mon, 12 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA82YzXLaMBDH7zyFx7nSIFnyF9dc0g6daZMO05lODxusGFFh
+        e4QMZTK8SY+8Ak/gF6uNGcckOfTQLDqZXSTvX/rtemU/DRzHnQtIXGfsPNVG
+        ba5Brxrzh+NKI5busL1O4EGoxijyolRgZJ41Vv74KGfi+Vc37HjX07VzKpHK
+        VT251OKF2Q5xftYadsNGlRarUplVT9iDzBKZpSdxrdM5iexGHV1mW4jG5ZZa
+        usNn/xpU2f4xN6YYj0abzeZ6I3/JBAxc5zodicxIsx19pRHxCHFPU3fDfrCT
+        1LOIv5dqrCBLjzcXWT9oJ0bVkzWotwXdgl6Uzk1eZmb7Omxvz8/jNsK7AP1F
+        seNy6jXQ0ffPk/vZXCzhKhEzuTxX8G/q/NAPCH2t6zx1/tPeRySMuR+9He1d
+        Nr/6o5Rw7mABq9rXBR604d871WKPhZip9g20sTfVqE9ZGGIziOI4YIgMPibw
+        YSq1xRh46Mf4GHzCAkQMX6q9zuyFEHmMxxcoBd9DZDCp9tU+E3aXgx8TFuM3
+        BhJQRBJTqRZQn7GspcBDQskF2jNqPdxBocBaBIzz3hMaB4FHmBdiIrgH0MJe
+        BIwR/M5cn8oxO/O0OljcDhijvYTEa8whR0TwqTqkYm3xo4hEnF6gDoIIFcJe
+        W82Akguci1iA2Q6moFJ7EXhxzDk6AhpRhvqidlAWl4EXchZhM+BBwFHr4FZK
+        i9+V/ehlR26/Jg92fwGQxVgr5hYAAA==
+    http_version: 
+  recorded_at: Thu, 08 Feb 2018 03:54:15 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryInfo_Q191.yml
+++ b/t/fixtures/vcr/CountryInfo_Q191.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q191%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Feb 2018 03:55:58 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '408'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 170593899, 71937478
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=08-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Mon,
+        12 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=08-Feb-2018;Path=/;HttpOnly;secure;Expires=Mon, 12 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7VUy27CMBC88xVWekUEk0IK96pSBVJLL5WqHkxYwgrHjhyb
+        gFD+rLf+WPOgeZS0UqVwsme93pm1xz71CLG2wNYWmZFTClK4ZyrK4BuxPGmE
+        VkerX07nbAU8w6EMDWcapcgQHMAzGvfQAGUyBx+jNNso+AHLlFzEeSyDcrNB
+        D6pZsUDeU6FJP5OuIDJcRzX1KxRrFP65gyJIqk7KxDyqjyFkIcsotPpVfM+4
+        KRa2Wocz247jeBDjDtdMs4FUvg1Coz7az3RKrfO+5LtA/WyafNn2krNe2smL
+        joZDar8u5i/eFgJ2swYPA8brwsrNHDWo5lolmjp0PHHGl8Lq99D1SYyo606n
+        l5yVNTpnvB3R8V0LZdPQXbFN0g6d4SXb2aRd87mOS2nLHTYeYpP0EPAZZ8LP
+        64P4v3HuIy0Fsj8u8Sq0D3IPSgRp50RuiN4CWUJoVhy9DP8q6uIb6VjWEtHH
+        nfRNu8Ouwvn4+aGQLFMzRL857Sq8TwoDIAsUGKVZbceej0nx9/aSL7qpls45
+        BgAA
+    http_version: 
+  recorded_at: Thu, 08 Feb 2018 03:55:58 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryList.yml
+++ b/t/fixtures/vcr/CountryList.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?item%20?itemLabel%20WHERE%20%7B%0A%20%20?item%20p:P31%20?statement%20.%0A%20%20?statement%20ps:P31%20wd:Q160016%20.%0A%20%20MINUS%20%7B%20?statement%20pq:P582%20?end%20%7D%20%20%20%20%20%20%23%20no%20longer%20a%20country%0A%20%20MINUS%20%7B%20?item%20wdt:P1552%20wd:Q47185282%20%7D%20%23%20not%20free%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20?itemLabel%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Feb 2018 03:54:10 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '1702'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 170591884, 59918793
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=08-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Mon,
+        12 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=08-Feb-2018;Path=/;HttpOnly;secure;Expires=Mon, 12 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA8WdzXLbNhDH73kKjs9uLFESP3KLHcd2/DGu7eSQTg4rEqFQ
+        k4AKAlLkTJ6mpx76FHmxUrKbpJ1e+8PFtmTT5G+Axf53sQt9fpYkewsl9V7y
+        Ivk8vBhersT125e/JHvaq25v//H7hcxVu5d8GP7oy/72Mqf60Pr+hyvn2tTa
+        NE9XP76ZPP2Xb3+1e8tvlmr71l5wem//+/sracPjLxbeL18cHKzX6+drfa9r
+        8fLcuuZAGa/95uDnNE33nq77sv/jnZ6e8x+3+9S1L1oxze4/K/PjHb89STtc
+        7KT976d52c7FaPl2x2eP9/3fGQuS0dTWOZoxL8Yoo9dNkERMnRyKm4ea5p2O
+        pySva7Y3NjTlpCxRyk7x1jkdodYZej/8MgIlDYkjliPSlRwOF7dSq35Be5Pp
+        FMV0c6ltTy88pDc5VG2jQ4ePY8oy6gdFW2TGIhptaMJxThIughcaMZ+RruPQ
+        tnoVQaHPUMZ+kDk78Xqq3INq7IqXdmU2QZF9vxYccjxDx9XJg27pqTsmJfph
+        aBuJIO0ydByDux8MMnktvaUnbAZyHg0GiQfO49F4jDIuVfJOuZrWPvmEtMsj
+        29puzttlPkIhO+vwUKQYsYy9l+RGV7wEIsPKI2fFR5B5qE1uli70uBwgZd3R
+        g6oWyY1ahnmrKzpHQGqCV8p04u7xrDpplK9spw2/8uRFFgHSxJq2s5wc02Pp
+        fXKnB8eJ6x9yVI+rIDXPWJL5reM2uZV2FYFzXJKS/bj3lt8GytHdg9eqHn7p
+        VZ3c+uFbn9iPyaWunDWq59HHKLr+VdNKYYLymeH6mjZRdDfhtRNT0RF1OiED
+        sRM13Bs3xXExQRldJ2ZDM6J7JicLPu08Jd3liVMKt8U8K1nECJnKHBXqJ2HQ
+        AZ20fD52lKGY2qgIjDnO+NOh7nsJeNjFTtoNv7rmJakDTkV7jWdESBVwak0d
+        nOCZSrLs7jSYRhyudArSS55VKkLgkWXkOJ6Zmt81mKUsYZQkQEp6yDMXY6oW
+        I1KXn/VOFF4NUqLW6CNUMk9owg2vVlHElXWb5MhK7/Egkow83kgn/OYWmut4
+        I0u8PLQYk2r8jXU1jjhGe33Oldngzr8s0U6fc22a2nbbXQ+/UMmVGr66rSLo
+        8a2PEYrt9FzwcLJAF6HzsB5CZhyRjJjPN67ZPPR8LX6K1k5eiOdL8Qu0IfhC
+        zcVYw9fATlDI3vqF5SFJt3mh54ovTJ9Mc5RRVQuvTO8V3uk0YUH9IkTo1J+g
+        a0/4pLq5Da7hLZMUe5dSSyN9JXjZ0igdoZytrHFth9a2bBE3fQRNkLGQtV6p
+        Hm8lTVlIjdfvwFPV8zWE7Lrq+oW0bXLWxwidh9U1R2mHJ/Uab6go0aVHfdKV
+        xYNKdBxtW9sVnuBCm0UurRF8GHM0NzAgNpbf/EnRroIBcoi2VOP42Bmtjri0
+        zlZVBEjUXdoH6eb6t6BwiY7O2Y1sO9XwsUSLs6+k03y3c1bmKGNwAZ+qKKFa
+        SouXK01RwnXyXkmMWhdUDVzpSpw0gS/sRTN2V7pREVbWCY3IyzrUeVi3Frqo
+        p5iSo3gt9zrC9mRWzlDIFi+vL0ZTlNBIx6ucMYq4DJJs/WSUzpB8wprlzklu
+        8HY0Ms66VrhsLdFo+XqhW71cDrMVPxWVDCSvbQTZOkUdiHU+NHgIkqbkAvv3
+        KSe7EwakUnWEsxXSMWmfN7aLUDownpGL7E3oI5wTgR4Zeiva+ORce9/vjkq9
+        UiuNl4dmI5z4IlT8yM5ynPOdNtVw/93YbouAH5u8I3jVrGCndWf5XZMCJTSD
+        p3Ha8BsK6MELt9utIVw9TEfobFWOz7MP45iijJtqodpW8RUU6Ec53GrlnCQX
+        yhqFH8DEgppGltbhBxShBc+3rV3JfQQtP4MhI3wmUFagkNvDm62JVMeVzlBx
+        YINfJC8/Or4Vs0APU30EPR9WIb6Zj8RcCt6KUMzQgXQ6uRBzz6em0dhzeE4j
+        HS4M0JFcq1rhfTOoNa61f3jspOW3qVHQr7/b5M52X//Y5Q+u3dc/TaWX+Adc
+        oYfm34l5iJDZzHNSINwtVHIoC+nwA6lKdPPhzjZ0fiRjB9IOURiex0TtcXCZ
+        wzPUuyXozs4FH9Fyio5oMJrfdUALZ+6Cu1cb3C5TFHH7M541IBHf3rshKlH4
+        Edyk/3hr9Pb4+KeTVGhRO+JJvx+U/7JTEdIHOblF9taFCIVCGfpJLO/EBPF4
+        rdCM9CfvJcansqEq6L3u5jJf/3u1TT482/785S8Au2MNm4IAAA==
+    http_version: 
+  recorded_at: Thu, 08 Feb 2018 03:54:11 GMT
+recorded_with: VCR 4.0.0

--- a/t/query/country_cities.rb
+++ b/t/query/country_cities.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_rel '../../lib/query/country_cities'
+
+describe Query::CountryCities do
+  describe 'Estonia (Q191)' do
+    before { VCR.insert_cassette('CountryCities Q191') }
+    after { VCR.eject_cassette }
+
+    let(:estonia_cities) { Query::CountryCities.new(id: 'Q191') }
+
+    describe 'Tallinn' do
+      subject { estonia_cities.data.find { |c| c.id == 'Q1770' } }
+
+      it 'should know its name' do
+        subject.name.must_equal 'Tallinn'
+      end
+
+      it 'should know its population' do
+        subject.population.must_equal '446055'
+      end
+
+      it 'should know its head of government' do
+        subject.head.name.must_equal 'Taavi Aas'
+      end
+
+      it 'should know its head of government office' do
+        subject.office.name.must_equal 'mayor of Tallinn'
+      end
+    end
+  end
+end

--- a/t/query/country_divisions.rb
+++ b/t/query/country_divisions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_rel '../../lib/query/country_info'
+
+describe Query::CountryDivisions do
+  describe 'Estonia (Q191)' do
+    before { VCR.insert_cassette('CountryDivisions Q191') }
+    after { VCR.eject_cassette }
+
+    let(:estonia_divisions) { Query::CountryDivisions.new(id: 'Q191') }
+
+    describe 'Harju County' do
+      subject { estonia_divisions.data.find { |c| c.id == 'Q180200' } }
+
+      it 'should know its name' do
+        subject.name.must_equal 'Harju County'
+      end
+
+      it 'should know its population' do
+        subject.population.must_equal '575601'
+      end
+
+      it 'should know its head of government' do
+        subject.head.name.must_equal 'Ülle Rajasalu'
+      end
+    end
+  end
+end

--- a/t/query/country_info.rb
+++ b/t/query/country_info.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_rel '../../lib/query/country_info'
+
+describe Query::CountryInfo do
+  describe 'Estonia (Q191)' do
+    before { VCR.insert_cassette('CountryInfo Q191') }
+    after { VCR.eject_cassette }
+
+    subject { Query::CountryInfo.new(id: 'Q191') }
+
+    it 'should know its name' do
+      subject.data.name.must_equal 'Estonia'
+    end
+
+    it 'should know its population' do
+      subject.data.population.must_equal '1315635'
+    end
+
+    it 'should know its head of government' do
+      subject.data.head.name.must_equal 'Jüri Ratas'
+    end
+
+    it 'should know its head of government office' do
+      subject.data.office.name.must_equal 'Prime Minister of Estonia'
+    end
+
+    it 'should know its legislature' do
+      subject.data.legislature.name.must_equal 'Riigikogu'
+    end
+  end
+end

--- a/t/query/country_list.rb
+++ b/t/query/country_list.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_rel '../../lib/query/country_list'
+
+describe Query::CountryList do
+  subject do
+    VCR.use_cassette('CountryList') { Query::CountryList.new.data }
+  end
+
+  it 'should get 145 countries' do
+    subject.count.must_equal 145
+  end
+
+  it 'should include free countries' do
+    subject.map(&:name).must_include 'Colombia'
+  end
+
+  it 'should not include non-free countries' do
+    subject.map(&:name).wont_include 'China'
+  end
+end


### PR DESCRIPTION
# What does this do?

Adds tests for all the classes in the Query module.

# Why was this needed?

These classes were missing tests.

# Relevant Issue(s)

# Implementation notes

These are mostly copied from their equivalent Page tests. This might seem like duplication but by having tests closer to the object it should allow us to change their behaviour with more confidence and certainty.

# Screenshots

# Notes to Reviewer

These should use the standardised VCR configuration that's being introduced in #17 but don't yet because that's not merged.

# Notes to Merger

