### PR TITLE
Tidy and make `require`s consistent throughout the application

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,9 +7,7 @@ require 'require_all'
 require 'sass'
 require 'sinatra'
 
-require_relative './lib/html_helper'
-require_rel './lib/page'
-require_rel './lib/query'
+require_all 'lib'
 
 class Integer
   def commify

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
-
 module Page
   class Country
     def initialize(country:, divisions:, cities:)

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
-
 module Page
   class Home
     def initialize(countries:)

--- a/lib/page/legislature.rb
+++ b/lib/page/legislature.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
+require_relative '../sparql'
 
 LegislatureStruct = SelfAwareStruct.new(:me, :type, :jurisdiction, :country, :seats, :chambers)
 

--- a/lib/query/country_cities.rb
+++ b/lib/query/country_cities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_rel 'country_divisions'
+require_relative 'country_divisions'
 
 module Query
   class CountryCities < CountryDivisions

--- a/lib/query/country_cities.rb
+++ b/lib/query/country_cities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
+require_rel 'country_divisions'
 
 module Query
   class CountryCities < CountryDivisions

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
+require_relative '../sparql'
 
 DivisionStruct = SelfAwareStruct.new(:me, :population, :legislature, :office, :head)
 

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
+require_relative '../sparql'
 
 CountryStruct = SelfAwareStruct.new(:me, :population, :executive, :head, :office, :legislature)
 

--- a/lib/query/country_list.rb
+++ b/lib/query/country_list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_rel '../sparql'
+require_relative '../sparql'
 
 module Query
   class CountryList

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-require_rel '../../lib'
+require_rel '../../lib/page/home'
 
 describe 'Homepage' do
   describe 'title' do

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require_rel '../../lib/page/home'
+require_relative '../../lib/page/home'
 
 describe 'Homepage' do
   describe 'title' do

--- a/t/query/country_cities.rb
+++ b/t/query/country_cities.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require_rel '../../lib/query/country_cities'
+require_relative '../../lib/query/country_cities'
 
 describe Query::CountryCities do
   describe 'Estonia (Q191)' do

--- a/t/query/country_divisions.rb
+++ b/t/query/country_divisions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require_rel '../../lib/query/country_info'
+require_relative '../../lib/query/country_info'
 
 describe Query::CountryDivisions do
   describe 'Estonia (Q191)' do

--- a/t/query/country_info.rb
+++ b/t/query/country_info.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require_rel '../../lib/query/country_info'
+require_relative '../../lib/query/country_info'
 
 describe Query::CountryInfo do
   describe 'Estonia (Q191)' do

--- a/t/query/country_list.rb
+++ b/t/query/country_list.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require_rel '../../lib/query/country_list'
+require_relative '../../lib/query/country_list'
 
 describe Query::CountryList do
   around { |test| VCR.use_cassette('CountryList', &test) }


### PR DESCRIPTION
# What does this do?

Removes unnecessary `require` lines, corrects them, makes them more specific, makes them consistent throughout the application, and uses the `requires_all` gem where it most makes sense.

Also:
Fixes #14.

# Why was this needed?

There were a few incorrect requires lines that were just working through luck. This tidies everything up so we can keep things nice and neat from here on in.

Now tests can run independently, run via Ruby or Rake, and the application can be run without modifications even if we add more files or directories below `lib`.

# Relevant Issue(s)

# Implementation notes

# Screenshots

# Notes to Reviewer

# Notes to Merger
