### PR TITLE
Show multiple P194 legislatures for a place

### DIFF
--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -41,7 +41,7 @@ module Query
     end
 
     def legislatures(place_id)
-      division_results.select { |r| r[:item] == place_id }.map { |i| i[:legislature] }
+      division_results.select { |r| r[:item] == place_id }.map { |i| i[:legislature] }.uniq
     end
   end
 end

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -2,7 +2,7 @@
 
 require_relative '../sparql'
 
-DivisionStruct = SelfAwareStruct.new(:me, :population, :legislature, :office, :head)
+DivisionStruct = SelfAwareStruct.new(:me, :population, :office, :head, :legislatures)
 
 module Query
   class CountryDivisions
@@ -12,7 +12,7 @@ module Query
 
     def data
       division_results.map do |r|
-        DivisionStruct.new(*r.values_at(:item, :population, :legislature, :office, :head))
+        DivisionStruct.new(*r.values_at(:item, :population, :office, :head), legislatures(r[:item]))
       end
     end
 
@@ -38,6 +38,10 @@ module Query
 
     def division_results
       @res ||= Sparql.new(sparql).results
+    end
+
+    def legislatures(place_id)
+      division_results.select { |r| r[:item] == place_id }.map { |i| i[:legislature] }
     end
   end
 end

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -13,7 +13,7 @@ module Query
     def data
       division_results.map do |r|
         DivisionStruct.new(*r.values_at(:item, :population, :office, :head), legislatures(r[:item]))
-      end
+      end.uniq
     end
 
     private

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -39,7 +39,7 @@ module Query
     end
 
     def legislatures
-      results.map { |i| i[:legislature] }
+      results.map { |i| i[:legislature] }.uniq
     end
   end
 end

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -2,7 +2,7 @@
 
 require_relative '../sparql'
 
-CountryStruct = SelfAwareStruct.new(:me, :population, :executive, :head, :office, :legislature)
+CountryStruct = SelfAwareStruct.new(:me, :population, :executive, :head, :office, :legislatures)
 
 module Query
   class CountryInfo
@@ -11,8 +11,8 @@ module Query
     end
 
     def data
-      h = Sparql.new(sparql).results.first
-      CountryStruct.new(*h.values_at(:country, :population, :executive, :head, :office, :legislature))
+      h = results.first
+      CountryStruct.new(*h.values_at(:country, :population, :executive, :head, :office), legislatures)
     end
 
     private
@@ -32,6 +32,14 @@ module Query
           SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
         }
       SPARQL
+    end
+
+    def results
+      @results ||= Sparql.new(sparql).results
+    end
+
+    def legislatures
+      results.map { |i| i[:legislature] }
     end
   end
 end

--- a/t/fixtures/vcr/CountryCities_Q30.yml
+++ b/t/fixtures/vcr/CountryCities_Q30.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q30%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 09 Feb 2018 03:46:39 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '3225'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 223118559, 76026938
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=09-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
+        13 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=09-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 13 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1d23Ibtxm+z1Ng3FtVxvmQO1OK7MiS40qauJlOLiASIjEE
+        ARW7K4bN5GH6AH2KvFixEqPQDd1kPNp/Ma0uLIk0SYDA//3nw49fIPRi4ezs
+        BfoS/VgelId3Njf9w7+hF751qxcHD7/P7LUL/YPbdNsF2/oU+0fp5sZP3a9/
+        Pb7s/lO3vx+fDG7um/LmLrv/ePjwEvR92cNPB/2usmu60DY7G7v2cebjfLu5
+        hyfRdpOPr7p/qt3cuv6pF132Lw5+ff7Ohu7hPxZte/vly5fr9fpw7Zd+Zlt7
+        mPL8pYutbzcv/yLxi+3bfjrYXWi7zY9W+2EVvgw2zu8/2MXdBR83Esqbsw37
+        N/POrdF3KS/RUVn7t+vuHPjHC/e7flxh9xux++9CMSYv/3p+djlduJX908xN
+        /erjLfyx7WnBlFTstxvb3v1Tn70qC2L+qeUGuYFzu0kZpRv0O1fxMVSe6Pty
+        Qwg3av9qg3zdiQ8BzRyaBNv49NuFd2H65MjighjxX9ccHmToKHVx6sPjNr54
+        2MzQXEUAcpWz1KBXce6Ca+rjKcwoySgFQphgWgoBibCvsp+i1zZPXdt6WIAR
+        rTDnCh5hOwT3DLJnkP1Pg0xKTTFnI4MsrVYpjgQzQvepLIMB7Wjhp3ae6gMZ
+        VZQybYBARo3m+8huMIxd2MUKfbWysXMBFmLUSMYwgYfYltTGlGGkcFJIMfYm
+        dU1bEFQfuoqtYAgHQheRShCiJSC+LjfhzjXlBeiqy9FlWIyVs5WcaniMbQlu
+        VIwxDgmx9wsf7MyF24W39eGMCInpp3wQT689EcbkPhfbYDA7tauiMJ0corcu
+        RrcZgZ1LUFpLLvofKiQzLg1XBMyVSJnsCVuM40z85DUMY39JLOmnFNFBvujr
+        7ObosrVxr+owpNxSRUhrguHl1vZKx5RbRkGKrUsbi71ZLthXaHsRXsQImNQi
+        StHeuQaIsK/vNujKbkLKI0gsCkxmx97VaOATZrjZpyMPoxoxI6mA5OJv3Z2P
+        6MR2YZp2DRA4QoP0Ix3bEGyFvlpCjNJEQlGZ5loQCkhl537p0IVdh/sIPqyR
+        SwmhZgRf7QOtje1HYsBs/DQ1rkJ8FSuACQxmeTBMNKzZserNDjhHGSNcE0hH
+        mV2hMz+d2jxLwCjiWql9CSkDumNjCl3o7rlGjSlBRjNODRiYCFGUSkPGMeN/
+        uQ3gML40GjPFx/DN/kJ94wouA4i4V13T+grjH4ZQtUP3QPzOMIkhnQzHXfm7
+        WmantdA70TgwAEgNeAWndrpsUrzzIVSovWmNJQGLsROMBQeNAp65GAur7XKG
+        Dk1IxiEjE1/HmbfR3qbgKzTCtWBEMSgbvNAZk5A2+GlyRZmZN65tRxDnkNzs
+        JOUWfSg/FhUSGekThqBhDu3MPcm2qI3NtEKHrsaCMgFXzmAENSNFIH/nJobh
+        a7JYLhoySnKW4ixFNMnOzWCNNCaFVvtC+0PbaB9dLJokm2f3993dunznm5Sb
+        EfRV0HzQYqKurrsKlQilFWbs2dH4NGRlDNNUaUBu8irOsluj1z62C/BwWB/Q
+        1qD1C51vKjX6lMSYyhH4mADNa7c5pLat8fwZ4RQq9VZQoiiBtLmPbfQuoNeH
+        6Cik2Y0L7TPax6Q2TATG4EUsnEG6mY9dm5Nv6zt9qTEVGEqoC2mMZhI6/eC4
+        m89thE4+6E2EEaoxt6Q2ZhCHMgJaI/bONotKuVvh82xfTe6zUfBZOhqRXBHI
+        JLlzVzgHmtgRHPQEEEEfCoJ8nLcpHqDjw6PDCoEktDZw1rUgBgtFx/HeFfsT
+        HfumzX7a9o8ffB77yoeGceQV01uA9iU5L3stKvkkrRvoSjgpqNpbxjt4temD
+        aP5D9w2kFGPI5keTVGflaR+x0mCFp4JQyT613EBcJhfF8IMNzQIWadxwpfEI
+        NacPlDZ2VhMHNTfj3T5GOjq2Cg0Y8awNP1EuP8OGEVBjerqwRU6/sXGapssR
+        PLSQ0eyvAnpvmwrj2AVFZCfQBHf6kBUF5251u6gxV0hyqeHavlCsmDSQYbBT
+        v0KXvSq6LB8zA6YygQ0kxCc2tH6Vco2OI0oJhlJDGTeaS9D2J627XfSBmMfa
+        sD9Pgl06YJVUCzpKOfkj4Y2plQqsQWvEnG3bKn20WH+yKckATW4xoxzSuXJV
+        GPqky3PXANdfKs6L+BrBtbKltDGxxdTeONdw6pIPa9stXZXwwmRfU7NB4GVE
+        sbQhc6uv0uo+PACfW824BtXIvykK4SKtbKXdyoUhRoK1BCm7ZoWRwxrfy8LM
+        coSnNEkwaBerlNuPbI96aEwzpaB6Nag+DiMhXcNXboY+LJwL4AlRlCnYhCjb
+        oG/dvMaGID2NCQmXZiuUoZBEdmRzCpuIXqc0W+1k5YAJTdCK/lfhuvt753L5
+        VyGpcaEFBXPHS0kVxyMV8++7CCDPqRagnduuumlTY2BVUEz2Jfo+B38+B0sF
+        SrDlEacp2nZhI7pI7aKZLnyYgWdN720LPlwxaXZNrDD+ww2XEsqgploQzgQH
+        LYp3aJLhgw9EYwLbNGua7aqsXiONlWs3YFGuYkmDtl14aH14mhZxV1JCBVIV
+        aOnBWYpzNHF2WmFJPJeU7nSBBBIjRBPIC3hrY7PtBljhDQijNJTXTAlOOWj6
+        9mXYoPsW8OCdlChoG6tvfZ776G21QOeaKyhxonvfLGiPwg/9XMVL1zRp1YB7
+        zmBHDLzqXbNthZMsOFeak2fz8om6QykuGGg3atv4FboA7+TBNZGYj5ACsgXS
+        mEFqTrCGrNO7sMH5eY3iiRltwHpwG0n3cqrBsPXOxukGnU9PbC6f4+B1IdBa
+        tnPX1CiemMEcuqEnUZhD5lN+Y5d1Bm45pVpI0EiHZGacSMf2Eg7QkQ3+JuUI
+        VzgoOOYC0il95q+vN6hQh7U3wNjSEnRQyrm3K18hsIiSYP0juCyo0rDJXT//
+        syla6dwGC99+3lDQ5plHKaRcvia6vM37p3WMT22SU3B/IdvrCR9OiK7sokYF
+        Bmuzjxyf7evPUcyYkJRj0EmYzkZ02aa+uV0LnAheSIfvmzo0tI19D6VR08Al
+        NqC2j4/R1dplu9A7Vs+TeNATxeUpZpLBztKdpmt0kt0GuEWHlsqoEdjHDprG
+        rSVhFLIzx1Fwd65OO54ZqQlU6ks/C0IxyFKtvrPzsu9MuZ3KAdyyjhQ6MyPg
+        7JHgRnWGc6MNaJpmqNFPyQwxWII1fy1wBu1+c+zWbtPPg5/Y3AbXtgfoNB/C
+        J5qZMcbK1UhtWDH9fz9PbhhvLCeCYwYZw/V52XudZ2sXwghRJsg8iA9+uvA1
+        5kEwTZmEmlotMDMGNE/gyObQT/xYg9eoMc5BS4feuTX6JgdnY4W2PFNagSni
+        jBGFJWjbV99OF+isqKTZuw48ams4ZB76qxweer9WSGZScPCZWZxQQqCHZ3e2
+        xuMXAu+bRPvssfssWcmZJApWVq5cRN914ed/RXSUu3+MEMEELX20q9saVTKu
+        JBcjnL0E7aW2dLm58S7U6DfkimuoAZ9CKgXb4umNzXdug97YHbMLKHu2kNk+
+        nj18A7VHahvVaWj2XvRwqlq0C+dXFQKMSQpWk0qkYUyDt3m6sr4dgb5Aqzu6
+        nHKNEpQWRVSPcPgc1g5oLSoQr/H8uaDQ5880pqDji9tDdD8prcLzJ5oTCZZa
+        YAiRFJK9nm1mFr3Nbg1fj92jnIJmWebbrkFHi+ybtsKMXkYk0+CFCgz0Dt77
+        tm2uu1xjLRLDArKOkRjNdRGu8G6XPiS25yLgUA/pY73wd8Ve8bMKu4AxzLSC
+        BjwzXGBQw2m6KJrtvMrzx0bgEZLaIQ2LI1+s8xhtjRKPGrk34DJQ4y6qBIZt
+        3LXonb82BrcZgctCRlLO3A+1RrKoERqzEc4fg1pQabqs9Pgxxwb++EFbPV2l
+        4GYVNhOjWlEM7T2guii2oN4bH1v03nahxgsQGCwniGClyKdyQ4ZRLnpbup+a
+        6eAbClPBjIDNCrJ5WSOJEcOh5hUpargEbaFxYZs+ZdguLTgboxJShJ8VRT2F
+        GiV4UZ8kh+Nh0hgKzsMmrmsD9AhkRgSX+2ZrDx3EnfaB2+lYgVsGqR28zs7F
+        5jrlGtUzZSQzYLFbLLHSDLz90be2my/A1QNBJGhV0fvy7hpJTJrdwSlAGMec
+        Qapmk+7mxoYaT19oI8AATgkmBrKma7LJKaJJTusRYocSMv3njYszl6uc7kCF
+        Klr5CFJcAmcIvHflBfcxqxovge0qcnAggFSlTlJu0Qe7iRXGcu4vgMBfAGhD
+        86/zna/z8DHbKSZ+OHz0/Rf93z/9G2ASmkfyzgAA
+    http_version: 
+  recorded_at: Fri, 09 Feb 2018 03:46:39 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryCities_Q801.yml
+++ b/t/fixtures/vcr/CountryCities_Q801.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q801%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Feb 2018 02:03:14 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '580'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 138875041, 222479898 189456378
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '242'
+      X-Cache:
+      - cp2018 miss, cp2006 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=16-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
+        20 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=16-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 20 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.5.211
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2aTW+jMBCG7/kVFnuNGowBQ27dU7VqV9qPw1arPUyDk1g1
+        HzKGbFTlvy8ERMkmW1UKodVqTmQmtucdT/yMI/E0IcRaC4gsMidPlVGZJei8
+        Nn8SSxoRW9PmeQsPQtVGlmaFAiPTpLbS5VIuxPOnbth+1fbZOZVYybyaXGjx
+        l9kMIb8qDbtprUqLvFAm7wl7kEkkk1UrrnGSVmQ3au8y20zULqvQ0po++0tQ
+        RfPF2phsPpttNpurjXyUERi4SvVqJhIjzXb2hTo0sNqJu2k/VCv0IN7vWM0V
+        JKv90iLph+ykqGqyBnVaziehixxUlchRzN52HwatNXer9/Nh+0wc26azH3e3
+        3xZrEcOHSCxkfBj+ddIC3+MOPdbVFn7ojXcc7ju+/694F9n9O9immqRL8kIZ
+        Dg/JQMm6fsBC93Swi2T6WWryEfQjmOOg/bM5eFVD7gaMvhj0MqUtErmQGVSD
+        tqcrPGkEIU9G4gmnQWjbyBPkCfIEeXI+T6rriYc8QZ4gT5Ang/CEctt1kCfI
+        E+QJ8uR8nniO6+L9BHmCPEGeDMET1+MceYI8QZ6cswGMhcwbESjfhSLXpSzf
+        IU+YE4Tj/d9hNg28UWkS1zQZCSCUuty3RwTI1zQhN4WKQGJDfqsDZHOKDRkb
+        MjZk5MkQPGGu5yNPkCfIk7MqTf1Tby1dDCg3IJfw/mDi8CC02Vi3X8ap54Yj
+        Hq/7NAFyD2sosV291S+s6h52iO0K29X/3K6aF5Mnuz8rMMTZMS0AAA==
+    http_version: 
+  recorded_at: Fri, 16 Feb 2018 02:03:14 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryDivisions_Q39.yml
+++ b/t/fixtures/vcr/CountryDivisions_Q39.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 09 Feb 2018 03:44:41 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '1069'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 22495063, 72853579
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2012 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=09-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
+        13 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=09-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 13 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1bX2/bNhB/z6cQ3Ncs5l9RyltSrMGGZOuQbig67IGWaYso
+        TRmUGC8t8s361i82+Q9cW3KaboiPBFbkwSEtkXf8/Y53vKM/niTJoFRyPEjO
+        k49to23eSVcvm38mA92o2eB0/XktR8osG/Nq7o1sdGWXrWoy0YX68t/2sdWo
+        m89tp1FTXbcve6c6zfUjyV+tDA+nS6mcqr1p6h3BRtqOtZ1uhFt3Jhsht0+t
+        upr7uVp2DbzTg9Mv/XfS+PUXZdPMz4fDxWJxttDv9Vg28qxy06GyjW7uh79h
+        nDM62Lz5cLo710bSvQn/nplzI+10Nbayu3NuZTHty06aw/K8lLapbFJNknef
+        PzldlP25d9Z9f/Kl8NtZdhWjK5UIQnj49ub6tijVTL4Yq0LP9sX4NhExQxkX
+        vC/YPn+eDYCUpY9MdhQEbqTTVfJKla4/6S5tn1tRgjFCiHx10iNSTprkZeVt
+        oc2KfH6PeydriY5ta4TRMLbWmsTi/kOEpsZ5llJYHmJBMoxwHDzsAAPFQ8HS
+        MDxszpIraUw7SnRcFJzTDHhLRBlJMYuEitK+b7roABES54QEIeSVkc7X8ZGR
+        ta4SAe+LmAlKA5DxWtqxk80BOL6z7//DPkoo4vm/Zt+3KdQbHsrRcgEZ8P06
+        WkgzjtG5UkFFBh/noTyLw7n2kAE7cSAGSMDfW0Hj414bYnFg7pFM8Ce20GP7
+        0l0sYNiWURbEjf4hjdQ1cOhOBGdPHF2PovaVayHe3Vo62oPFTBgHAftSOQuV
+        miOtGWeAqblLJRunC5Xc6lllYQmdpowzEQGf9wCGY7MIcwJQVt1JWKR5GxXl
+        JAKkO8rDnfY4INat1n70+ZM9GJYfNQbJGKUZigHnA0sAB3YeJtNZmaopvQMG
+        naQi40JEklHsrQEY6oHqLO/8FNjIc5ZxEgneu9qDIS0gU3cX0k2lBw/MKI8h
+        MOsoD5XBQAJyB7+Yz5X9oIxJLnxdK+fKCtxzMyE4fyJlAWbUTywIGAtyFoQF
+        P1kbhgS4PY1xEkOY/vXF+E6Ao+WvKeb4UKH+mUoi3fGhkGz/ggRn175Qzirg
+        gFxQgnAkAVp3BcAQD3Td5FLWyvywzInXRSknDfQBHNE040GLAI+uABj0oPH5
+        Wt3bRo6BsU4FynkWQ/b0wAqAFbtzSKx/0ePHqt3Hdcuc4yxsaa+vOhTEKUNB
+        dvJXTo8q76bwNZH/cCfl+a26pz4Y3rkIdWFZTial9DW8fS+vB6Norgf3lwHs
+        kjCGTKK+KT18bm19yOYRWHhXfTCQCeSx+o0utK2gL1mzTORRYLyvPRjEnAfZ
+        w3/2DriyTWiOBQ6wd7+Wzmg5a+XoKQ6GssCBLl/5MfQPySgWLIbC9p7uMEBT
+        lGeQbvnHei4LldzoplGmHamr7/qHrCcP/wACkNo5YTsAAA==
+    http_version: 
+  recorded_at: Fri, 09 Feb 2018 03:44:41 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryInfo_Q183.yml
+++ b/t/fixtures/vcr/CountryInfo_Q183.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q183%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 09 Feb 2018 03:41:30 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '429'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 174037535, 59591365
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2018 miss, cp2018 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=09-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
+        13 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=09-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 13 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.141.17
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1Wy26CQBTd+xUTujUyKIq4a5vUjS6abpo0XYxwhYnDQIYB
+        JI3/Xh6WR1GTJthF64q5j7nnzJ3LyXwMEFJcILaCFugjMzIzJiLMzTekWH7E
+        pUiVYbVckQ2w3A78IGJEUp/nFuzBiiSNoWVUyQwcGmbZkYBvZpVSkDh+K6e/
+        3VIL6lUZQO8Z0cMwpy4gjJgMG+w3lNuUO8cTlE5Un6RKLLwyDSB3KZGgyrD2
+        x4RFZcCVMlioapIko4TuqE0kGfnCUYFLKlP1WZtPlOO+w1eBZm/aePn2CrNZ
+        elIUHWOsqa/r1YvlgkfubLCoR1iTWLWZUQmiHatJz7WxOdYx7jJrXkTvrdBn
+        2mTexaxno3dEjKcmPnEB7YnuCW06M7pIxwntG0s3DWzgWRev9Ru2UfceWzDC
+        nQIA+M/HZgnCIzy9cINXgX0COw+ipR+D4F7WAuRv0VkyHfHomc5DxG0IBZGn
+        x+oqmPfcAUbQGsQuK35myK7a/EeXcAsY88Wp5g9KPjc5/U05neqGadzk9Can
+        f0BOJXEusvjnylq+aAeHTxR4C3qPCwAA
+    http_version: 
+  recorded_at: Fri, 09 Feb 2018 03:41:30 GMT
+recorded_with: VCR 4.0.0

--- a/t/query/country_cities.rb
+++ b/t/query/country_cities.rb
@@ -29,4 +29,18 @@ describe Query::CountryCities do
       end
     end
   end
+
+  describe 'United States of America (Q30)' do
+    around { |test| VCR.use_cassette('CountryCities Q30', &test) }
+
+    let(:cities) { Query::CountryCities.new(id: 'Q30').data }
+
+    describe 'Los Angeles (Q65)' do
+      subject { cities.find { |c| c.id == 'Q65' } }
+
+      it 'should have two legislatures' do
+        subject.legislatures.count.must_equal 2
+      end
+    end
+  end
 end

--- a/t/query/country_cities.rb
+++ b/t/query/country_cities.rb
@@ -47,4 +47,18 @@ describe Query::CountryCities do
       end
     end
   end
+
+  describe 'Israel (Q801)' do
+    around { |test| VCR.use_cassette('CountryCities Q801', &test) }
+
+    let(:cities) { Query::CountryCities.new(id: 'Q801').data }
+
+    describe 'Jerusalem (Q1218)' do
+      subject { cities.find { |c| c.id == 'Q1218' } }
+
+      it 'should have one legislature' do
+        subject.legislatures.count.must_equal 1
+      end
+    end
+  end
 end

--- a/t/query/country_cities.rb
+++ b/t/query/country_cities.rb
@@ -38,6 +38,10 @@ describe Query::CountryCities do
     describe 'Los Angeles (Q65)' do
       subject { cities.find { |c| c.id == 'Q65' } }
 
+      it 'should only be listed once' do
+        cities.select { |c| c.id == 'Q65' }.count.must_equal 1
+      end
+
       it 'should have two legislatures' do
         subject.legislatures.count.must_equal 2
       end

--- a/t/query/country_divisions.rb
+++ b/t/query/country_divisions.rb
@@ -25,4 +25,18 @@ describe Query::CountryDivisions do
       end
     end
   end
+
+  describe 'Switzerland (Q39)' do
+    around { |test| VCR.use_cassette('CountryDivisions Q39', &test) }
+
+    let(:divisions) { Query::CountryDivisions.new(id: 'Q39').data }
+
+    describe 'Canton of Glarus (Q11922)' do
+      subject { divisions.find { |c| c.id == 'Q11922' } }
+
+      it 'should have two legislatures' do
+        subject.legislatures.count.must_equal 2
+      end
+    end
+  end
 end

--- a/t/query/country_divisions.rb
+++ b/t/query/country_divisions.rb
@@ -34,6 +34,10 @@ describe Query::CountryDivisions do
     describe 'Canton of Glarus (Q11922)' do
       subject { divisions.find { |c| c.id == 'Q11922' } }
 
+      it 'should only be listed once' do
+        divisions.select { |c| c.id == 'Q11922' }.count.must_equal 1
+      end
+
       it 'should have two legislatures' do
         subject.legislatures.count.must_equal 2
       end

--- a/t/query/country_info.rb
+++ b/t/query/country_info.rb
@@ -26,7 +26,17 @@ describe Query::CountryInfo do
     end
 
     it 'should know its legislature' do
-      subject.legislature.name.must_equal 'Riigikogu'
+      subject.legislatures.first.name.must_equal 'Riigikogu'
+    end
+  end
+
+  describe 'Germany (Q183)' do
+    around { |test| VCR.use_cassette('CountryInfo Q183', &test) }
+
+    subject { Query::CountryInfo.new(id: 'Q183').data }
+
+    it 'should have two legislatures' do
+      subject.legislatures.count.must_equal 2
     end
   end
 end

--- a/views/_legislature.erb
+++ b/views/_legislature.erb
@@ -1,0 +1,5 @@
+<% if legislature %>
+  <a href="/legislature/<%= legislature.id %>"><%= legislature.name || '???' %></a>
+<% else %>
+  <i>unknown</i>
+<% end %>

--- a/views/place_info.erb
+++ b/views/place_info.erb
@@ -15,11 +15,17 @@
       <% end %>
     </li>
 
-    <li>Legislature:
-      <% if place.legislature %>
-        <a href="/legislature/<%= place.legislature.id %>"><%= place.legislature.name || '???' %></a>
+    <li>
+      <% if place.legislatures.count > 1 %>
+        Legislatures:
+        <ul>
+          <% place.legislatures.each do |legislature| %>
+            <li><%= erb :_legislature, locals: { legislature: legislature } %></li>
+          <% end %>
+        </ul>
       <% else %>
-        <i>unknown</i>
+        Legislature:
+        <%= erb :_legislature, locals: { legislature: place.legislatures.first } %>
       <% end %>
     </li>
   </ul>


### PR DESCRIPTION
# What does this do?

Shows multiple legislatures next to a place if that place has multiple legislatures returned in the query.

# Why was this needed?

Previously if a place had multiple truthy statements for its Legislative Body For (P194) property then these were not shown (for countries) or resulted in duplicate entries (for FLACS and cities).

# Relevant Issue(s)

Fixes #8.
Fixes #34.

# Implementation notes

# Screenshots
![screenshot from 2018-02-16 13-51-08](https://user-images.githubusercontent.com/48945/36291667-90168b56-1320-11e8-856d-d27dec26e772.png)
![screenshot from 2018-02-16 13-51-30](https://user-images.githubusercontent.com/48945/36291668-905f1b50-1320-11e8-98d9-3d4a2324c8a4.png)
![screenshot from 2018-02-16 13-51-42](https://user-images.githubusercontent.com/48945/36291669-90b3630e-1320-11e8-8bc6-cafa505269ec.png)

# Notes to Reviewer

# Notes to Merger
