### PR TITLE
Factor out Sparql::Datum class

### DIFF
--- a/lib/sparql.rb
+++ b/lib/sparql.rb
@@ -11,10 +11,8 @@ class Sparql
   end
 
   def results
-    bindings.map do |r|
-      r.map do |k, v|
-        [k, v[:type] == 'uri' && v[:value].include?('http://www.wikidata.org/entity/') ? v[:value].split('/').last : v[:value]]
-      end.to_h
+    bindings.map do |row|
+      row.map { |field, value| [field, Datum.new(value).to_s] }.to_h
     end
   end
 
@@ -34,5 +32,29 @@ class Sparql
 
   def bindings
     raw_json[:results][:bindings]
+  end
+
+  # https://www.wikidata.org/wiki/Special:ListDatatypes
+  class Datum
+    def initialize(hash)
+      @datum = hash
+    end
+
+    def type
+      datum[:type]
+    end
+
+    def value
+      datum[:value]
+    end
+
+    def to_s
+      return value.split('/').last if type == 'uri' and value.include?('http://www.wikidata.org/entity/')
+      value
+    end
+
+    private
+
+    attr_reader :datum
   end
 end


### PR DESCRIPTION
For now this is largely just a stub, other than providing a simple
`to_s` method that takes care of reducing entity URIs down to only the
plain ID.

As this grows to handle more different data-types we should look into
factoring it out into a gem of its own, as we're doing very similar
things in multiple places.