### PR TITLE
Auto-inflate LabeledItem structs from Queries

### DIFF
--- a/lib/page/legislature.rb
+++ b/lib/page/legislature.rb
@@ -19,22 +19,22 @@ module Page
     def legislature
       h = Sparql.new(sparql).results.first
       Legislature.new(
-        h[:legislature],
-        h[:legislatureLabel],
-        Item.new(h[:type], h[:typeLabel]),
-        Item.new(h[:jurisdiction], h[:jurisdictionLabel]),
-        Item.new(h[:country], h[:countryLabel]),
+        h[:legislature].id,
+        h[:legislature].name,
+        h[:type],
+        h[:jurisdiction],
+        h[:country],
         h[:seats],
         chambers
       )
     end
 
     def type
-      @type ||= Sparql.new(type_sparql).results.find { |h| h[:isaLabel].include? 'cameral legislature' }[:isaLabel]
+      @type ||= Sparql.new(type_sparql).results.map { |h| h[:isa].name }.find { |name| name.include? 'cameral legislature' }
     end
 
     def chambers
-      @chambers ||= Sparql.new(parts_sparql).results.map { |h| Item.new(h[:part], h[:partLabel]) }
+      @chambers ||= Sparql.new(parts_sparql).results.map { |r| r[:part] }
     end
 
     def unicameral?
@@ -51,11 +51,10 @@ module Page
 
     private
 
-    Item = Struct.new(:id, :name)
     Legislature = Struct.new(:id, :name, :type, :jurisdiction, :country, :seats, :chambers)
 
     def types
-      @types ||= Sparql.new(type_sparql).results.map { |r| r[:isaLabel] }.to_set
+      @types ||= Sparql.new(type_sparql).results.map { |r| r[:isa].name }.to_set
     end
 
     def type_sparql

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -11,12 +11,12 @@ module Query
     def data
       division_results.map do |r|
         Division.new(
-          r[:item],
-          r[:itemLabel],
+          r[:item].id,
+          r[:item].name,
           r[:population],
-          Item.new(r[:legislature], r[:legislatureLabel]),
-          Item.new(r[:office], r[:officeLabel]),
-          Item.new(r[:head], r[:headLabel])
+          r[:legislature],
+          r[:office],
+          r[:head]
         )
       end
     end
@@ -25,7 +25,6 @@ module Query
 
     attr_reader :id
 
-    Item = Struct.new(:id, :name)
     Division = Struct.new(:id, :name, :population, :legislature, :office, :head)
 
     def sparql

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -11,13 +11,13 @@ module Query
     def data
       h = Sparql.new(sparql).results.first
       Country.new(
-        h[:country],
-        h[:countryLabel],
+        h[:country].id,
+        h[:country].name,
         h[:population],
-        Item.new(h[:executive], h[:executiveLabel]),
-        Item.new(h[:head], h[:headLabel]),
-        Item.new(h[:office], h[:officeLabel]),
-        Item.new(h[:legislature], h[:legislatureLabel])
+        h[:executive],
+        h[:head],
+        h[:office],
+        h[:legislature]
       )
     end
 
@@ -25,7 +25,6 @@ module Query
 
     attr_reader :id
 
-    Item = Struct.new(:id, :name)
     Country = Struct.new(:id, :name, :population, :executive, :head, :office, :legislature)
 
     def sparql

--- a/lib/query/country_list.rb
+++ b/lib/query/country_list.rb
@@ -5,12 +5,10 @@ require_rel '../sparql'
 module Query
   class CountryList
     def data
-      Sparql.new(sparql).results.map { |h| Country.new(h[:item], h[:itemLabel]) }
+      Sparql.new(sparql).results.map { |r| r[:item] }
     end
 
     private
-
-    Country = Struct.new(:id, :name)
 
     def sparql
       @sparql ||= <<~SPARQL


### PR DESCRIPTION
When a SPARQL query returns a "foo" and a "fooLabel" pair, automatically turn those into a Struct with an `id` and a `name`.

This means that we don't need to replicate this logic each time we deal with results.