### PR TITLE
Introduce a SelfAwareStruct

### DIFF
--- a/lib/page/legislature.rb
+++ b/lib/page/legislature.rb
@@ -2,6 +2,8 @@
 
 require_rel '../sparql'
 
+LegislatureStruct = SelfAwareStruct.new(:me, :type, :jurisdiction, :country, :seats, :chambers)
+
 module Page
   class Legislature
     def initialize(id:)
@@ -18,7 +20,7 @@ module Page
 
     def legislature
       h = Sparql.new(sparql).results.first
-      Legislature.new(*h.values_at(:legislature, :type, :jurisdiction, :country, :seats), chambers)
+      LegislatureStruct.new(*h.values_at(:legislature, :type, :jurisdiction, :country, :seats), chambers)
     end
 
     def type
@@ -42,16 +44,6 @@ module Page
     end
 
     private
-
-    Legislature = Struct.new(:me, :type, :jurisdiction, :country, :seats, :chambers) do
-      def id
-        me.id
-      end
-
-      def name
-        me.name
-      end
-    end
 
     def types
       @types ||= Sparql.new(type_sparql).results.map { |r| r[:isa].name }.to_set

--- a/lib/page/legislature.rb
+++ b/lib/page/legislature.rb
@@ -18,15 +18,7 @@ module Page
 
     def legislature
       h = Sparql.new(sparql).results.first
-      Legislature.new(
-        h[:legislature].id,
-        h[:legislature].name,
-        h[:type],
-        h[:jurisdiction],
-        h[:country],
-        h[:seats],
-        chambers
-      )
+      Legislature.new(*h.values_at(:legislature, :type, :jurisdiction, :country, :seats), chambers)
     end
 
     def type
@@ -51,7 +43,15 @@ module Page
 
     private
 
-    Legislature = Struct.new(:id, :name, :type, :jurisdiction, :country, :seats, :chambers)
+    Legislature = Struct.new(:me, :type, :jurisdiction, :country, :seats, :chambers) do
+      def id
+        me.id
+      end
+
+      def name
+        me.name
+      end
+    end
 
     def types
       @types ||= Sparql.new(type_sparql).results.map { |r| r[:isa].name }.to_set

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -2,6 +2,8 @@
 
 require_rel '../sparql'
 
+DivisionStruct = SelfAwareStruct.new(:me, :population, :legislature, :office, :head)
+
 module Query
   class CountryDivisions
     def initialize(id:)
@@ -10,23 +12,13 @@ module Query
 
     def data
       division_results.map do |r|
-        Division.new(*r.values_at(:item, :population, :legislature, :office, :head))
+        DivisionStruct.new(*r.values_at(:item, :population, :legislature, :office, :head))
       end
     end
 
     private
 
     attr_reader :id
-
-    Division = Struct.new(:me, :population, :legislature, :office, :head) do
-      def id
-        me.id
-      end
-
-      def name
-        me.name
-      end
-    end
 
     def sparql
       @sparql ||= <<~SPARQL

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -10,14 +10,7 @@ module Query
 
     def data
       division_results.map do |r|
-        Division.new(
-          r[:item].id,
-          r[:item].name,
-          r[:population],
-          r[:legislature],
-          r[:office],
-          r[:head]
-        )
+        Division.new(*r.values_at(:item, :population, :legislature, :office, :head))
       end
     end
 
@@ -25,7 +18,15 @@ module Query
 
     attr_reader :id
 
-    Division = Struct.new(:id, :name, :population, :legislature, :office, :head)
+    Division = Struct.new(:me, :population, :legislature, :office, :head) do
+      def id
+        me.id
+      end
+
+      def name
+        me.name
+      end
+    end
 
     def sparql
       @sparql ||= <<~SPARQL

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -10,22 +10,22 @@ module Query
 
     def data
       h = Sparql.new(sparql).results.first
-      Country.new(
-        h[:country].id,
-        h[:country].name,
-        h[:population],
-        h[:executive],
-        h[:head],
-        h[:office],
-        h[:legislature]
-      )
+      Country.new(*h.values_at(:country, :population, :executive, :head, :office, :legislature))
     end
 
     private
 
     attr_reader :id
 
-    Country = Struct.new(:id, :name, :population, :executive, :head, :office, :legislature)
+    Country = Struct.new(:me, :population, :executive, :head, :office, :legislature) do
+      def id
+        me.id
+      end
+
+      def name
+        me.name
+      end
+    end
 
     def sparql
       @sparql ||= <<~SPARQL

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -2,6 +2,8 @@
 
 require_rel '../sparql'
 
+CountryStruct = SelfAwareStruct.new(:me, :population, :executive, :head, :office, :legislature)
+
 module Query
   class CountryInfo
     def initialize(id:)
@@ -10,22 +12,12 @@ module Query
 
     def data
       h = Sparql.new(sparql).results.first
-      Country.new(*h.values_at(:country, :population, :executive, :head, :office, :legislature))
+      CountryStruct.new(*h.values_at(:country, :population, :executive, :head, :office, :legislature))
     end
 
     private
 
     attr_reader :id
-
-    Country = Struct.new(:me, :population, :executive, :head, :office, :legislature) do
-      def id
-        me.id
-      end
-
-      def name
-        me.name
-      end
-    end
 
     def sparql
       @sparql ||= <<~SPARQL

--- a/lib/sparql.rb
+++ b/lib/sparql.rb
@@ -84,3 +84,21 @@ class Sparql
     attr_reader :datum
   end
 end
+
+# This is a bit of a nasty hack that's pushing the concept of a Struct
+# right to its limit. We might want to look into pushing this up to a
+# full-blown class, but for now it's an experiment whilst we see if it
+# has sufficient value first.
+#
+# Usage: treat like a normal Struct, except if one of the args is a
+# `LabelledItem` called :me, it has methods for descending into that
+# to avoid the ugliness of `country.country.name` etc.
+class SelfAwareStruct < Struct
+  def id
+    me.id
+  end
+
+  def name
+    me.name
+  end
+end


### PR DESCRIPTION
The results of SPARQL queries usually require a [LabelledItem](https://github.com/everypolitician/legislative-explorer/pull/28) to represent
the primary item we're dealing with (e.g. the country, or legislature), as
well as other LabelledItems to represent associated concepts. But if we
treat all of those the same, we end up with the ugly indirection of having
to say `country.country.id` instead of just `country.id`

So add a subclass of Struct that, when given an argment of `:me`, knows how
to call `id` and `name` on that.

This is a bit of a nasty hack that's pushing the concept of a Struct right
to its limit. We might want to look into pushing this up to a full-blown
class, but for now it's an experiment whilst we see if it has sufficient
value first.