### PR TITLE
Don't show abolished legislatures

### DIFF
--- a/lib/query/country_cities.rb
+++ b/lib/query/country_cities.rb
@@ -12,7 +12,10 @@ module Query
           FILTER (?population > 250000)
           OPTIONAL { ?item wdt:P6 ?head }
           OPTIONAL { ?item wdt:P1313 ?office }
-          OPTIONAL { ?item wdt:P194 ?legislature }
+          OPTIONAL {
+            ?item wdt:P194 ?legislature
+            MINUS { ?legislature wdt:P576 ?legislatureEnd }
+          }
           SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
         }
         ORDER BY DESC(?population)

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -29,7 +29,10 @@ module Query
           OPTIONAL { ?item wdt:P1082 ?population }
           OPTIONAL { ?item wdt:P6 ?head }
           OPTIONAL { ?item wdt:P1313 ?office }
-          OPTIONAL { ?item wdt:P194 ?legislature }
+          OPTIONAL {
+            ?item wdt:P194 ?legislature
+            MINUS { ?legislature wdt:P576 ?legislatureEnd }
+          }
           SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
         }
         ORDER BY DESC(?population) ?itemLabel

--- a/lib/query/country_divisions.rb
+++ b/lib/query/country_divisions.rb
@@ -41,7 +41,7 @@ module Query
     end
 
     def legislatures(place_id)
-      division_results.select { |r| r[:item] == place_id }.map { |i| i[:legislature] }.uniq
+      division_results.select { |r| r[:item] == place_id }.map { |i| i[:legislature] }.compact.uniq
     end
   end
 end

--- a/lib/query/country_info.rb
+++ b/lib/query/country_info.rb
@@ -25,7 +25,10 @@ module Query
         {
           BIND(wd:#{id} AS ?country)
           OPTIONAL { ?country wdt:P1082 ?population }.
-          OPTIONAL { ?country wdt:P194 ?legislature }.
+          OPTIONAL {
+            ?country wdt:P194 ?legislature
+            MINUS { ?legislature wdt:P576 ?legislatureEnd }
+          }.
           OPTIONAL { ?country wdt:P208 ?executive }.
           OPTIONAL { ?country wdt:P6 ?head }.
           OPTIONAL { ?country wdt:P1313 ?office }.
@@ -39,7 +42,7 @@ module Query
     end
 
     def legislatures
-      results.map { |i| i[:legislature] }.uniq
+      results.map { |i| i[:legislature] }.compact.uniq
     end
   end
 end

--- a/t/fixtures/vcr/Basic_web_requests.yml
+++ b/t/fixtures/vcr/Basic_web_requests.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q39%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -21,17 +21,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:13:04 GMT
+      - Wed, 21 Feb 2018 07:16:31 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
-      - '343'
+      - '271'
       Connection:
       - keep-alive
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2002
+      - wdqs2001
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,13 +41,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 212258469, 163931771 98399078
+      - 138239185, 98399234 163931716
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '138'
+      - '356'
       X-Cache:
-      - cp2012 miss, cp2006 hit/1
+      - cp2006 miss, cp2006 hit/10
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -66,16 +66,538 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA7VTPW+DMBDd8yssd40CJFXzsVWVOqVDlaVS1cGBg5xqDDI2
-        hEb892JIDSRRpErJ5Hv3+e7ZPowIoTtgASUrcqhBDXMmMwM/CfUTLZQs6dia
-        a7YFbnCapJozhYkwCPbga4U5DIBN5hBhVmdrCSfQpjQkjqd1JmGIPnRWGyBf
-        NdFqbKhLyDRXWY/9FkWAIjpu0DpJt4lNbLyqTMG4qJZIx50/Z1y3gZ1S6cpx
-        iqKYFPiNAVNsksjIAaFQlc77bEmPZdVffV+a4ThTbUf2O8+anlPX9ZyPt/XG
-        30HMHgLwMWa8z8sWc1Qgh7GO82LqeXPXPSfWv4ZbC/G0eJx7F8ToXsbNpXeX
-        3vx84OChDmfuY77iTERNexD/V3ZToPoBWfcIrmx6l9GvEJggeanX85Ffvdy7
-        EnjOMoi3vCRJSC7p0ZxV+0dH1S/TnhVgYQQAAA==
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:04 GMT
+  recorded_at: Wed, 21 Feb 2018 07:16:31 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:32 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '235'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 93353742, 260431765 241996828
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '356'
+      X-Cache:
+      - cp2018 miss, cp2006 hit/2
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA71SsWrDMBDd/RWHZhOnuNDiLVuGLm3H0uGCr84RRTbSyW4I
+        /vfKlnGdkDWZxL177957oHMCoPaEpYICzmEIY4vWDeMXqAatqDS+b7gjreA7
+        kPp0kFlyXotbKHdsSjbVpI4gTFdm1gjJqaEBUt6ySv/xFrWPi71IU2RZ13Wr
+        jg9couCqtlVGRlhO2fvLa/68flKTtE+XZlPUC8ffoy40mmo8TmZpOofRLGRR
+        3w60rb0jqH/gg5pQPeRA4ZbcHCGJQe7fO8/XD+z9SQZlLL7xTgKN8apy/BNJ
+        /we4evmXTQIAAA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:33 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:34 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '200'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 18226595, 261370062 251956659
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '355'
+      X-Cache:
+      - cp2025 miss, cp2006 hit/2
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA21QywqDQAy8+xXLnkUpWGj9hl56Lj3EGjQ0bmU3qxXx3+sL
+        a6GnMDOZzJA+UEqXCLlWqepHMMIGrJvgTWlyoMN5XCBD1uo+rgzhZLLoPIvb
+        +TIyOZli9S6kWm5sSzMjXY0Tpb0lHX75BtgvQilSp3Hctm3U0pNyEIhetojR
+        CEkXXw+nc5Ic9Wodwl3WWvQn8F1xymCK+TaafebWhUnQAv/vk9EDqklWjAU5
+        BvEWt/h5DstvguEDSy3MrlMBAAA=
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:34 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:35 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '271'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 139429960 136407997, 98399242
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '4'
+      X-Cache:
+      - cp2006 hit/1, cp2006 miss
+      X-Cache-Status:
+      - hit-local
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:35 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:37 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '271'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 139429960 136407997, 252228738 98399243
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '5'
+      X-Cache:
+      - cp2006 hit/1, cp2006 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:37 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:38 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '271'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 139429960 136407997, 252228740 98399243
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '7'
+      X-Cache:
+      - cp2006 hit/1, cp2006 hit/2
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:38 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:40 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '271'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 139429960 136407997, 260431774 98399243
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '8'
+      X-Cache:
+      - cp2006 hit/1, cp2006 hit/3
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:40 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q39%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?country%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:16:41 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '342'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 93712755, 98399248
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2018 miss, cp2006 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7VTy26DMBC85yss9xoFSKrmcasq9ZQeqlwqVT04sJBVjUHG
+        htCIfy+G1EASRaqUnOzZ18yY5TAihO6ABZSsyKEGNcyZzAz8JNRPtFCypGN7
+        XbMtcIPTJNWcKUyEQbAHXyvMYQBsMYcIs7paSziBtqQRcTxtMAlD9KG7tQny
+        VQutxka6hExzlfXUb1EEKKKjgzZIOie2sImqMgUToloiHXfxnHHdJnZKpSvH
+        KYpiUuA3BkyxSSIjB4RCVTrvsyU9tlV//QO3t+Z7WjzOvQucvc8xpDQTLG1/
+        +qyZO3Vdz/l4W2/8HcTsIQAfY8b72mwzRwVymOt0L6aeN3fdc2HdZtz86d2l
+        Nz8nHCzqkHMf8xVnImrGg/i/y02B6gdkPSO44vQu1K8QmCR5qe35yK9u3V0F
+        PGcZxFtekiQkl96jOav2Hx1Vv2zHMGhhBAAA
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:16:42 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
@@ -97,7 +619,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:13:05 GMT
+      - Wed, 21 Feb 2018 07:16:43 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -117,13 +639,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 17625930, 261409559 252228649
+      - 17625930, 261186724 252228649
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '137'
+      - '355'
       X-Cache:
-      - cp2025 miss, cp2006 hit/1
+      - cp2025 miss, cp2006 hit/2
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -167,7 +689,7 @@ http_interactions:
         tq6Vc9MKPFoz4cM143EUHA8sCBgfchaYD79aG4YO69gewznglxfjJxUA8niK
         +cG7W49003p//DWm6z+8ntz9D5FCYkaJOwAA
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:05 GMT
+  recorded_at: Wed, 21 Feb 2018 07:16:43 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q39%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
@@ -189,7 +711,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:13:07 GMT
+      - Wed, 21 Feb 2018 07:16:44 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -209,15 +731,15 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 138567632, 231585739
+      - 138567632, 250711789 231585740
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '216'
       X-Cache:
-      - cp2006 miss, cp2006 miss
+      - cp2006 miss, cp2006 hit/1
       X-Cache-Status:
-      - miss
+      - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
@@ -243,7 +765,7 @@ http_interactions:
         /rLYQ7YeFRIFkD3TS7ufXuq9R/XcjRs4m+2fqg+8NBIZDBIVWsTIR4jONv0f
         uGp+AJQA6YYaBAAA
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:07 GMT
+  recorded_at: Wed, 21 Feb 2018 07:16:44 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?item%20?itemLabel%20WHERE%20%7B%0A%20%20?item%20p:P31%20?statement%20.%0A%20%20?statement%20ps:P31%20wd:Q160016%20.%0A%20%20MINUS%20%7B%20?statement%20pq:P582%20?end%20%7D%20%20%20%20%20%20%23%20no%20longer%20a%20country%0A%20%20MINUS%20%7B%20?item%20wdt:P1552%20wd:Q47185282%20%7D%20%23%20not%20free%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20?itemLabel%0A
@@ -265,7 +787,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:13:08 GMT
+      - Wed, 21 Feb 2018 07:16:45 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -285,13 +807,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 138660699, 261409563 163931713
+      - 138660699, 261370077 163931713
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '155'
+      - '372'
       X-Cache:
-      - cp2006 miss, cp2006 hit/1
+      - cp2006 miss, cp2006 hit/2
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -349,527 +871,5 @@ http_interactions:
         3hq921v9aScVWtSOeNLvu8i/bNUA4YOUXCJ768IAiUIJ+piSd2KCeDxXaEba
         k/cyxCPLUBX0Xrdzma/xYHtOSh/5j6fTRx+e7f7/8hc138BunoIAAA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:09 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:10 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2001
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 138239185, 98399139 163931716
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '155'
-      X-Cache:
-      - cp2006 miss, cp2006 hit/5
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:10 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:12 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '235'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2002
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 93353742, 241996851 241996828
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '155'
-      X-Cache:
-      - cp2018 miss, cp2006 hit/1
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA71SsWrDMBDd/RWHZhOnuNDiLVuGLm3H0uGCr84RRTbSyW4I
-        /vfKlnGdkDWZxL177957oHMCoPaEpYICzmEIY4vWDeMXqAatqDS+b7gjreA7
-        kPp0kFlyXotbKHdsSjbVpI4gTFdm1gjJqaEBUt6ySv/xFrWPi71IU2RZ13Wr
-        jg9couCqtlVGRlhO2fvLa/68flKTtE+XZlPUC8ffoy40mmo8TmZpOofRLGRR
-        3w60rb0jqH/gg5pQPeRA4ZbcHCGJQe7fO8/XD+z9SQZlLL7xTgKN8apy/BNJ
-        /we4evmXTQIAAA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:12 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:13 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '200'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2003
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 18226595, 245785722 251956659
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '155'
-      X-Cache:
-      - cp2025 miss, cp2006 hit/1
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA21QywqDQAy8+xXLnkUpWGj9hl56Lj3EGjQ0bmU3qxXx3+sL
-        a6GnMDOZzJA+UEqXCLlWqepHMMIGrJvgTWlyoMN5XCBD1uo+rgzhZLLoPIvb
-        +TIyOZli9S6kWm5sSzMjXY0Tpb0lHX75BtgvQilSp3Hctm3U0pNyEIhetojR
-        CEkXXw+nc5Ic9Wodwl3WWvQn8F1xymCK+TaafebWhUnQAv/vk9EDqklWjAU5
-        BvEWt/h5DstvguEDSy3MrlMBAAA=
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:13 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:15 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2001
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 138239185, 98399143 163931716
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '159'
-      X-Cache:
-      - cp2006 miss, cp2006 hit/6
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:15 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:16 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2001
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 138239185, 98399145 163931716
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '161'
-      X-Cache:
-      - cp2006 miss, cp2006 hit/7
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:17 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:18 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2001
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 138239185, 245785727 163931716
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '163'
-      X-Cache:
-      - cp2006 miss, cp2006 hit/8
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:18 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:13:19 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2001
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 138239185, 231585750 163931716
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '164'
-      X-Cache:
-      - cp2006 miss, cp2006 hit/9
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:13:20 GMT
+  recorded_at: Wed, 21 Feb 2018 07:16:46 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/Basic_web_requests.yml
+++ b/t/fixtures/vcr/Basic_web_requests.yml
@@ -2,112 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?item%20?itemLabel%20WHERE%20%7B%0A%20%20?item%20p:P31%20?statement%20.%0A%20%20?statement%20ps:P31%20wd:Q160016%20.%0A%20%20MINUS%20%7B%20?statement%20pq:P582%20?end%20%7D%20%20%20%20%20%20%23%20no%20longer%20a%20country%0A%20%20MINUS%20%7B%20?item%20wdt:P1552%20wd:Q47185282%20%7D%20%23%20not%20free%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20?itemLabel%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 20 Feb 2018 06:19:32 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '1702'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.13
-      X-Served-By:
-      - wdqs1004
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 219678793, 158575486 158603184, 83700405
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '43'
-      X-Cache:
-      - cp1058 pass, cp3008 hit/1, cp3008 miss
-      X-Cache-Status:
-      - hit-local
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 94.173.239.224
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA8Wdy3bbNhCG93kKHq/dWldesosdx3bs+Li2k0V6shiRKIma
-        BFQQkCLl5Gm66qJPkRcrJbtJ2tNtP2wsixJFfgeX+WcwGH56liQHjZLqIHme
-        fBreDG9X4vrd25+TA+1Vd3D4+HolC9UeJB+GL30+3J3mVB9a33935kKbSpv6
-        6ezHg8nTr3z91v6Q3yzV7tBBcPrg8NvxlbTh8YPG++Xzo6P1ev3jWj/oSrz8
-        aF19pIzXfnP002QyOXg67/Ph91d6us9/XO5j1z5vxdT7X1bm+yt+vZN2ONlJ
-        +99386JdiNHy9YrPHq/7vzPmJKOprHM0Y5aPUUav6yCJmCo5FrcIFc07G89I
-        XlfvLmxoymlRoJSd4kfnbISOztD74cMIlDQkjliMSFNyPJzcSqX6hrYmsxmK
-        6RZS2Z6eeEhrcqzaWocOb8cJy6i3ih6RKYtotKEJxxlJ2AQvNGI2J03HsW31
-        KoJCn6OM/SBz9uL1XLmtqu2Kl3ZFOkWRfb8WHHI8R9vVyVa3dNcdkxL9OLS1
-        RJB2KdqOwT0MAzJ5Jb2lO2wKcp4MAxJ3nMej8RhlXKrknXIVrX0mBelWnjS6
-        pQmzKTnznNjWdgt+5slGKGRnHe5s5SOWsfeS3OqSF3mk43zirPgIQhYdk5ul
-        Cz0ueEjherJVZZPcqmVYtLqkoyCk6nmpTCfuAV83IAflS9tpw888WZ5GgDSx
-        uu08I9v0VHqf3OvBcOL6h2zV0zJIxTMWZATvtE3upF1F4BwXpFNy2nvLL3Rl
-        6PrIK1UNH3pVJXd+eOkT+0vyRpfOGtXz6GMUXf+qaaUwRfnMcH5FD1F0veSV
-        E1PiMYMp6YidqeHa+FAc51OU0XViNjQjuip01vCB9RlpLs+cUvhYzNKCRYwQ
-        i81QoX4WBh3QSctHnEcpiqmNisCY4Yw/HOu+l4C7XWyn3fCza1aQOuBctNd4
-        RIRUAefWVMEJHqkkV4DOg6nF4UonJ63kRakiOB5pSrbjhan4VYP5hCWMEgSY
-        kBbywsXoqvmI1OUXvRNF57tM0cHopd3wUg5FXFm3SU6s9B73sEhZ/lo64Vd+
-        0EDAa1ni2aH5mJSqr62rcMQxutXnUpkNbhmLAt3oc6lNXdlutyTgG5Vcq+Gv
-        25nLHl8XGKHYTi8E97VydBK6DOvBn8QRSXfycuPqzbbnU/EnaOrklXg+Ez9H
-        9wNfqYUYa/gU2CkK2VvfWB6SNJtXeqH4vPTpLEMZVdl4ZXqv8I1OUxbUNyHC
-        Rv0pOveEj6pb2OBqfmSSYu+NVFJLXwqe0zOajFDOVta4tkMTP3aImz6CJkhZ
-        yEqvVI/vJJ2wkBpPboG7qucT7Nh51fWNtG1y0cdwnYfZNUNphzv1Gt9tUKBT
-        j/qoS4s7lWg72rayKzzAhe6keGON4M2YobGBAbG2fBWbCZpyP0AO3paqHe87
-        o6kDb6yzZRkBEjWXdivdQv8WFC7R0T67kd02Lrwt0czla+k0vxU4LTKUMbiA
-        d1WUUC2lxXN5ZijhOnmvJEYiCKoGrnUpTurAZ72iEbtrXasIM+uURuRlHWo8
-        rFsLndSTz8hWvJEHHWF5Mi3mKGSL557noxlKaKTjVc4YRVwGSXZ2Msq2iWzK
-        Dsu9kdzge7VIP+tG4bK1QL3lm0a3erkceiteFJV0JG9sBNk6Qw2IdT7UuAsy
-        mZAT7N8lQPbb76VUVYTCA5MxOT5vbRchdWA8JyfZ29BHKKKAVgy9E218cqm9
-        7/eVUq/VSuPpoekIJ74KJd+y8wznfKdNOVx/37a7JODHHdARrGqas926s/yq
-        SY4SmsHSOG34BQW0KsHdbmkIVw+zEdpblePj7EM7TlDGTdmotlV8BgX6JIc7
-        rZyT5EpZo/DqRCyoqWVpHV69B014vmvtSh4iaPk5DBnhkUBpjkLuKhtbEymP
-        K0cLcN7Z4Jvkchic/B43EnMpeIZ+Pkcb0unkSswDH7FFXbLhPo10uL1EW3Kt
-        KoVvJ0FH41r77eMGU7ywBup5bVwEsc425ZffbXJvuy9/7AMHN+7Ln6bUS/zB
-        Vmgp+Xsx2wghzSwjO+99o5JjaaTDyzQV6KrDva3pwEjKNqQd3C88gImOx0EU
-        DPdQ7aege7sQvEWLGdqiwWh+uQHNmLkP7kFt8HE5QRF3/+PhAhLx7YMb/C6F
-        F6Ym7cdbo3dF1Z9KqNCyfcSTfisf/6JTLsLDO8i1sbcuRMgQStHnk7wTE8Tj
-        SUJz0p68lxjPKkNV0HvdLWSx/vdsm3x4tvv/818H3cxkk4IAAA==
-    http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:37 GMT
-- request:
-    method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q39%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
     body:
       encoding: US-ASCII
@@ -118,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -127,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:32 GMT
+      - Wed, 21 Feb 2018 07:13:04 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -135,9 +29,9 @@ http_interactions:
       Connection:
       - keep-alive
       Server:
-      - nginx/1.11.13
+      - nginx/1.11.6
       X-Served-By:
-      - wdqs1005
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -147,26 +41,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 142086498, 90901705, 83922488 82793498
+      - 212258469, 163931771 98399078
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '532'
+      - '138'
       X-Cache:
-      - cp1045 pass, cp3007 miss, cp3008 hit/2
+      - cp2012 miss, cp2006 hit/1
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -181,7 +75,7 @@ http_interactions:
         3vx84OChDmfuY77iTERNexD/V3ZToPoBWfcIrmx6l9GvEJggeanX85Ffvdy7
         EnjOMoi3vCRJSC7p0ZxV+0dH1S/TnhVgYQQAAA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:37 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:04 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
@@ -194,7 +88,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -203,17 +97,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:33 GMT
+      - Wed, 21 Feb 2018 07:13:05 GMT
       Content-Type:
       - application/sparql-results+json
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1062'
       Connection:
       - keep-alive
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs1003
+      - wdqs2003
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -223,28 +117,28 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 289377509, 157877475, 79903210
+      - 17625930, 261409559 252228649
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Accept-Ranges:
-      - bytes
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '137'
       X-Cache:
-      - cp1051 pass, cp3008 miss, cp3008 pass
+      - cp2025 miss, cp2006 hit/1
       X-Cache-Status:
-      - miss
+      - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -273,10 +167,10 @@ http_interactions:
         tq6Vc9MKPFoz4cM143EUHA8sCBgfchaYD79aG4YO69gewznglxfjJxUA8niK
         +cG7W49003p//DWm6z+8ntz9D5FCYkaJOwAA
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:38 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:05 GMT
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q39%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q39%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -286,7 +180,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -295,7 +189,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:33 GMT
+      - Wed, 21 Feb 2018 07:13:07 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -303,9 +197,9 @@ http_interactions:
       Connection:
       - keep-alive
       Server:
-      - nginx/1.11.13
+      - nginx/1.11.6
       X-Served-By:
-      - wdqs1004
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -315,26 +209,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 86574244, 17159668, 80768258 78044244
+      - 138567632, 231585739
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '531'
+      - '0'
       X-Cache:
-      - cp1061 pass, cp3010 miss, cp3008 hit/2
+      - cp2006 miss, cp2006 miss
       X-Cache-Status:
-      - hit-front
+      - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -349,7 +243,113 @@ http_interactions:
         /rLYQ7YeFRIFkD3TS7ufXuq9R/XcjRs4m+2fqg+8NBIZDBIVWsTIR4jONv0f
         uGp+AJQA6YYaBAAA
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:38 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:07 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?item%20?itemLabel%20WHERE%20%7B%0A%20%20?item%20p:P31%20?statement%20.%0A%20%20?statement%20ps:P31%20wd:Q160016%20.%0A%20%20MINUS%20%7B%20?statement%20pq:P582%20?end%20%7D%20%20%20%20%20%20%23%20no%20longer%20a%20country%0A%20%20MINUS%20%7B%20?item%20wdt:P1552%20wd:Q47185282%20%7D%20%23%20not%20free%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20?itemLabel%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:13:08 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '1705'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 138660699, 261409563 163931713
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '155'
+      X-Cache:
+      - cp2006 miss, cp2006 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA8WdS3LbRhCG9z4FSmvFIkESD+8sWZZkPUqRZC+c8qIJjIEJ
+        gRlmMEOadPk0WWWRU/hiASnFdqqSZT5sRBEkCHw1j/67p3vw+VkUHdRKyoPo
+        RfS5f9O/XYnrdm9/iQ60V+3B4ePrlcxVcxB96L/05XB3mlNdaHz3w5lzbUpt
+        qqezHw9GT7/y7Vv7Q36zVLtDB8Hpg8Pvx1fShMcPau+XL46O1uv187Ve6FK8
+        PLeuOlLGa785+jmO44On874c/nilp/v8x+U+tc2LRky1/2Vlfrzitztp+pOd
+        NP9+Ny+buRgt36747PG6/ztjRjKa0jpHM6bZGGX0ugoSiSmjY3HzUNK80/GU
+        5HXV7sKGppzkOUrZKn50Tkfo6Ayd7z8cgJKGxBHzEWlKjvuTGylVV9PWZDpF
+        Md1cStvREw9pTY5VU+nQ4u0Ys4x6q+gRmbCIRhuacJyShHXwQiOmM9J0HNtG
+        rwZQ6DOUsetlzl68niu3VZVd8dIuTyYosu/WgkOOZ2i7Otnqhu66Y1KiH4em
+        kgGkXYK2Y3CLfkBGr6WzdIdNQM6TfkDijvN4NB6jjEsVvVOupLVPOiHH5Ylt
+        bDvnx2U6QiFb63BXJBuxjJ2X6E4XvAQi3coTZ8UPIPPQMblZutDhcoCUdSdb
+        VdTRnVqGeaMLOkZAaoJXyrTiFnhUnRyUr2yrDT/zpFkyAKQZqtvOUrJNT6Xz
+        0YPuDSeuf8hWPS2ClDxjTsa3TpvoXprVAJzjnJTsp523/DJQiq4evFZl/6FX
+        ZXTv+5cush+ja104a1THo49RdP2rppXCBOUz/fklPUTR1YTXTkxBe9TxhHTE
+        zlR/bXwojrMJyuhaMRuaEV0zOav5sPOUNJdnTil8LKZJziIOEKlMUaF+Fnod
+        0ErDx2NHCYqpjRqAMcUZfzrWXScBd7vYTrvhZ9c0J3XAuWiv8YgIqQLOrSmD
+        EzxSSabdnQdTicOVTkZayYtCDeB4JAnZjhem5FcNZjFLOEgQICYt5IUboqtm
+        I1KXX3ROFJ0NMkEHo5dmw0s5FHFl3SY6sdJ53MMiZfkbaYVf+UEDAW9kiedO
+        ZmNSqr6xrsQRx2ghzKUyG9wy5jlaBnOpTVXadrck4GsV3aj+r9uZyw5fFxih
+        2E7PBfe1MnQSugzr3p/EEUl38nLjqs224xPVYzSx8Eo8n6eeodWyV2ouxho+
+        QXSCQnbW15aHJM3mlZ4rPmt7Mk1RRlXUXpnOK7wMaMKC+joMUMY+Qeee8Em1
+        cxtcxY9MUuxdSymVdIXgOT2jeIRyNrLGtR2a+LFD3HQDaIKEhSz1SnV4nWXM
+        Qmo8uQXuqp5PsGPnVdfV0jTRRTeE69zPrilK29+p13i1QY5OPeqTLizuVKLt
+        aJvSrvAAF1pJcW2N4M2YorGBHrGy/B4vMZpy30P23paqHO87o6kD19bZohgA
+        EjWXdivtXP8WFC7R0T67kV0ZF96WaObyjbSaLwVO8hRlDC7gXRUlVEtp8Fye
+        KUq4jt4rGSIRBFUDN7oQJ1Xgs17RiN2NrtQAM+uERuRlHWo8rFsLndSTTclW
+        vJWFHmB5MslnKGSD555noylKaKTlVc4YRVwGiXZ2cpCyiXTCDsu9kdzgtVqk
+        n3WrcNmao97yba0bvVz2vRXfMpR0JG/tALJ1ihoQ63yocBckjskJ9u8tQPbl
+        91KocoCNB+IxOT7vbDtA6sB4Rk6yd6EbYBMFdD/Ne9HGR5fa+26/j+iNWmk8
+        PTQZ4cRXoeBbdpbinO+0Kfrr79t2lwT8WAE9gFVNMrZbt5ZfNclQQtNbGqcN
+        v6CA7kpwv1sawtXDdIT2VuX4OHvfjjHKuClq1TSKz6BAn3Nwr5VzEl0paxS+
+        OxELaipZWofv3oMmPN83diWLAbT8DIYc4IE5SYZC7nY2tmagPK54hooDG3wd
+        vfzo+FLMDN1p9BH0sp+F+GI+EnMpeClCNkMb0unoSsyCD02jvmd/n0ZaXBig
+        LblWpcLrZtDRuNZ++1hJyy9To6Bff7fRg22//rGPH9y6r3+aQi/xpz+hO8o/
+        iNkOENlMU1IgPNQqOpZaWny3phxdfHiwFR0fSdiGtL0Xhscx0fHYm8z+Hsr9
+        FPRg54K3aD5FWzQYza86oIkzD8Et1AYflzGKuPsfjxqQiG8XrvdKFL4/NWk/
+        3hq921v9aScVWtSOeNLvu8i/bNUA4YOUXCJ768IAiUIJ+piSd2KCeDxXaEba
+        k/cyxCPLUBX0Xrdzma/xYHtOSh/5j6fTRx+e7f7/8hc138BunoIAAA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:13:09 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -362,7 +362,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -371,7 +371,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:33 GMT
+      - Wed, 21 Feb 2018 07:13:10 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -381,7 +381,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs1003
+      - wdqs2001
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -391,28 +391,28 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 282562415, 90676967 88566274, 83763111
+      - 138239185, 98399139 163931716
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Accept-Ranges:
-      - bytes
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '531'
+      - '155'
       X-Cache:
-      - cp1051 pass, cp3007 hit/4, cp3008 miss
+      - cp2006 miss, cp2006 hit/5
       X-Cache-Status:
-      - hit-local
+      - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -424,7 +424,7 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:38 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:10 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -437,7 +437,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -446,7 +446,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:33 GMT
+      - Wed, 21 Feb 2018 07:13:12 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -454,9 +454,9 @@ http_interactions:
       Connection:
       - keep-alive
       Server:
-      - nginx/1.11.13
+      - nginx/1.11.6
       X-Served-By:
-      - wdqs1004
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -466,26 +466,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 86117658, 18025938, 84083821 78044247
+      - 93353742, 241996851 241996828
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '531'
+      - '155'
       X-Cache:
-      - cp1061 pass, cp3010 miss, cp3008 hit/2
+      - cp2018 miss, cp2006 hit/1
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -498,7 +498,7 @@ http_interactions:
         3w60rb0jqH/gg5pQPeRA4ZbcHCGJQe7fO8/XD+z9SQZlLL7xTgKN8apy/BNJ
         /we4evmXTQIAAA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:39 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:12 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -511,7 +511,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -520,7 +520,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:33 GMT
+      - Wed, 21 Feb 2018 07:13:13 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -528,9 +528,9 @@ http_interactions:
       Connection:
       - keep-alive
       Server:
-      - nginx/1.11.13
+      - nginx/1.11.6
       X-Served-By:
-      - wdqs1004
+      - wdqs2003
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -540,26 +540,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 82721996, 17554570, 84018154 80767949
+      - 18226595, 245785722 251956659
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '531'
+      - '155'
       X-Cache:
-      - cp1061 pass, cp3010 miss, cp3008 hit/2
+      - cp2025 miss, cp2006 hit/1
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -571,7 +571,7 @@ http_interactions:
         CEkXXw+nc5Ic9Wodwl3WWvQn8F1xymCK+TaafebWhUnQAv/vk9EDqklWjAU5
         BvEWt/h5DstvguEDSy3MrlMBAAA=
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:39 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:13 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -584,7 +584,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -593,7 +593,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:34 GMT
+      - Wed, 21 Feb 2018 07:13:15 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -603,7 +603,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs1003
+      - wdqs2001
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -613,101 +613,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 289477723, 90836904 90676968, 83955674
+      - 138239185, 98399143 163931716
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '159'
       X-Cache:
-      - cp1051 pass, cp3007 hit/1, cp3008 miss
-      X-Cache-Status:
-      - hit-local
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 94.173.239.224
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:39 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 20 Feb 2018 06:19:34 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs1003
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 289477723, 90836904 90676968, 83763114 83955675
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '0'
-      X-Cache:
-      - cp1051 pass, cp3007 hit/1, cp3008 hit/1
+      - cp2006 miss, cp2006 hit/6
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -721,7 +646,7 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:39 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:15 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -734,7 +659,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -743,7 +668,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:34 GMT
+      - Wed, 21 Feb 2018 07:13:16 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -753,7 +678,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs1003
+      - wdqs2001
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -763,26 +688,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 289477723, 90836904 90676968, 84083827 83955675
+      - 138239185, 98399145 163931716
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '161'
       X-Cache:
-      - cp1051 pass, cp3007 hit/1, cp3008 hit/2
+      - cp2006 miss, cp2006 hit/7
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -796,7 +721,7 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:39 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:17 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -809,7 +734,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -818,7 +743,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 06:19:34 GMT
+      - Wed, 21 Feb 2018 07:13:18 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -828,7 +753,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs1003
+      - wdqs2001
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -838,26 +763,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 289477723, 90836904 90676968, 76147832 83955675
+      - 138239185, 245785727 163931716
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '163'
       X-Cache:
-      - cp1051 pass, cp3007 hit/1, cp3008 hit/3
+      - cp2006 miss, cp2006 hit/8
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -871,5 +796,80 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 06:19:39 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:18 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:13:19 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '271'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2001
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 138239185, 231585750 163931716
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '164'
+      X-Cache:
+      - cp2006 miss, cp2006 hit/9
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:13:20 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/Basic_web_requests.yml
+++ b/t/fixtures/vcr/Basic_web_requests.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:31 GMT
+      - Wed, 21 Feb 2018 07:19:14 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2001
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,13 +41,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 138239185, 98399234 163931716
+      - 139429960 136407997, 251672412 98399243
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '356'
+      - '162'
       X-Cache:
-      - cp2006 miss, cp2006 hit/10
+      - cp2006 hit/1, cp2006 hit/4
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -74,7 +74,7 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:31 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:14 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P527%20?part%20.%0A%20%20?part%20wdt:P31/wdt:P279*%20wd:Q10553309%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -96,7 +96,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:32 GMT
+      - Wed, 21 Feb 2018 07:19:15 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -106,7 +106,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2002
+      - wdqs2003
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -116,15 +116,15 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 93353742, 260431765 241996828
+      - 94189963 94063070, 186312237
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '356'
+      - '162'
       X-Cache:
-      - cp2018 miss, cp2006 hit/2
+      - cp2018 hit/1, cp2006 miss
       X-Cache-Status:
-      - hit-front
+      - hit-local
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
@@ -148,7 +148,7 @@ http_interactions:
         3w60rb0jqH/gg5pQPeRA4ZbcHCGJQe7fO8/XD+z9SQZlLL7xTgKN8apy/BNJ
         /we4evmXTQIAAA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:33 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:15 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?isa%20?isaLabel%20WHERE%0A%7B%0A%20%20wd:Q382118%20wdt:P31%20?isa%20.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -170,7 +170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:34 GMT
+      - Wed, 21 Feb 2018 07:19:16 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -180,7 +180,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2003
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -190,15 +190,15 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 18226595, 261370062 251956659
+      - 18331657 18487420, 261370162
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '355'
+      - '162'
       X-Cache:
-      - cp2025 miss, cp2006 hit/2
+      - cp2025 hit/1, cp2006 miss
       X-Cache-Status:
-      - hit-front
+      - hit-local
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
@@ -221,7 +221,7 @@ http_interactions:
         CEkXXw+nc5Ic9Wodwl3WWvQn8F1xymCK+TaafebWhUnQAv/vk9EDqklWjAU5
         BvEWt/h5DstvguEDSy3MrlMBAAA=
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:34 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:17 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -243,7 +243,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:35 GMT
+      - Wed, 21 Feb 2018 07:19:18 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -263,88 +263,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 139429960 136407997, 98399242
+      - 139429960 136407997, 261340141 98399243
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '4'
+      - '166'
       X-Cache:
-      - cp2006 hit/1, cp2006 miss
-      X-Cache-Status:
-      - hit-local
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
-        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
-        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
-        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
-        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
-        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
-        AA==
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:35 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:16:37 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '271'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2002
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 139429960 136407997, 252228738 98399243
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '5'
-      X-Cache:
-      - cp2006 hit/1, cp2006 hit/1
+      - cp2006 hit/1, cp2006 hit/5
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -371,7 +296,7 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:37 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:18 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -393,7 +318,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:38 GMT
+      - Wed, 21 Feb 2018 07:19:20 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -413,13 +338,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 139429960 136407997, 252228740 98399243
+      - 139429960 136407997, 261370166 98399243
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '7'
+      - '168'
       X-Cache:
-      - cp2006 hit/1, cp2006 hit/2
+      - cp2006 hit/1, cp2006 hit/6
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -446,7 +371,7 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:38 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:20 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
@@ -468,7 +393,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:40 GMT
+      - Wed, 21 Feb 2018 07:19:21 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -488,13 +413,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 139429960 136407997, 260431774 98399243
+      - 139429960 136407997, 261064553 98399243
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '8'
+      - '170'
       X-Cache:
-      - cp2006 hit/1, cp2006 hit/3
+      - cp2006 hit/1, cp2006 hit/7
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -521,10 +446,10 @@ http_interactions:
         GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
         AA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:40 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:21 GMT
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q39%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?country%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?legislature%20?legislatureLabel%20?jurisdiction%20?jurisdictionLabel%20?country%20?countryLabel%20?seats%20?part%20?partLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q382118%20AS%20?legislature)%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1342%20?seats%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P1001%20?jurisdiction%20%7D.%0A%20%20OPTIONAL%20%7B%20?legislature%20wdt:P17%20?country%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -543,11 +468,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:41 GMT
+      - Wed, 21 Feb 2018 07:19:23 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
-      - '342'
+      - '271'
       Connection:
       - keep-alive
       Server:
@@ -563,89 +488,13 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 93712755, 98399248
+      - 139429960 136407997, 251956857 98399243
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '171'
       X-Cache:
-      - cp2018 miss, cp2006 miss
-      X-Cache-Status:
-      - miss
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA7VTy26DMBC85yss9xoFSKrmcasq9ZQeqlwqVT04sJBVjUHG
-        htCIfy+G1EASRaqUnOzZ18yY5TAihO6ABZSsyKEGNcyZzAz8JNRPtFCypGN7
-        XbMtcIPTJNWcKUyEQbAHXyvMYQBsMYcIs7paSziBtqQRcTxtMAlD9KG7tQny
-        VQutxka6hExzlfXUb1EEKKKjgzZIOie2sImqMgUToloiHXfxnHHdJnZKpSvH
-        KYpiUuA3BkyxSSIjB4RCVTrvsyU9tlV//QO3t+Z7WjzOvQucvc8xpDQTLG1/
-        +qyZO3Vdz/l4W2/8HcTsIQAfY8b72mwzRwVymOt0L6aeN3fdc2HdZtz86d2l
-        Nz8nHCzqkHMf8xVnImrGg/i/y02B6gdkPSO44vQu1K8QmCR5qe35yK9u3V0F
-        PGcZxFtekiQkl96jOav2Hx1Vv2zHMGhhBAAA
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:42 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:16:43 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '1062'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2003
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 17625930, 261186724 252228649
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '355'
-      X-Cache:
-      - cp2025 miss, cp2006 hit/2
+      - cp2006 hit/1, cp2006 hit/8
       X-Cache-Status:
       - hit-front
       Strict-Transport-Security:
@@ -664,108 +513,15 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+1bW2/bNhR+z68Q3Ncs5lWU8tYWbbAh2TqkG4oOe6Al2iZK
-        UwYlxUuL/LO+9Y+NvsCVLadpi/iQQPtkk5bIc/h950bSH06SZDBVshwk58kH
-        3/DNG+nqZfOfZKAbNRucrj8v5UiZZWNezVsjG13ZZasaj3WhPn/bPrYadfO5
-        7TRqomv/cuvUXnP9SPKvl+HudCmVU3Vrmroj2EjbUtvJRrh1Z7IRcvvUqqu5
-        natl16B1enD6uf9Gmnb9w7Rp5ufD4WKxOFvod7qUjTyr3GSobKOb2+GfGOeM
-        DjZv3p1259pIujPhfzNzbqSdrMZWtjvnVhbjX3bSHJbnubRNZZNqnLz99NHp
-        Ytqfu7Puu5Mvhd/O0lWMrlQiCOHhm6vL62KqZvJJqQo92xXj60TEDGVc8L5g
-        u/x5NABSlt4z2VEQuJJOV8lLNXX9Sbu0fWxFCcYIIfLFSY9IOWmS51VrC21W
-        5Gt3uHeylujYtkYYDWNr3iQWt+8jNDXOs5TC8hALkmGE4+DhHjBQPBQsDcPD
-        5iy5kMb4UaLjouCcZsAuEWUkxSwSKkr7rtlHB4iQOCckCCEvjHRtHR8ZmQ+V
-        CNgvYiYoDUDGS2lLJ5sDcPxk34/DPkoo4vk3s+/rFOoNDxVouYBM+P4YLaQp
-        YwyuVFCRwed5KM/iCK49ZMAqDsQACfiXFzQ+7vkUiwNzj2SCP+BCjx1Lu1hA
-        sc3bHCDbnslamV+uG1k2sPCmAuU8gGe5cB7erls5tAJgWAeqIdc6L4leF1M5
-        BoYeZ4imGQ9q2feuAFi+jHEY6JWzUNuyxLvwDHBb9pmSjdOFSq71rLLA/ixl
-        nIkY/FkXYChHljIUhM0vnR5VrZvAY/0dddbjY91TH857iTDVvrLqRsKizX0F
-        lJMI0N5THmyjm/MgWP/WOmCkCfW8xgFKjlfSGS1nXo6e4mCpKAmTj1y2hQ9Y
-        ChhoQQnCIo59jf0VAIvZuQh1kCrH46lsa2VDHFuiaI4t+8sAt1ufh8G+MlUz
-        bR0w8CQVGReR2Ht/DWBQzygLgvnf0khdAwPusxb2wK0ImKRtT3uwpE3gQGC3
-        JfSdKIoFQ1FA3dEdzJMHug71tgUuunHOMk4i8eFd7WGQpr4KhUT6RT2XhUqu
-        dNMo40cKwGwCWXd6a25Hnz7aEjwpzRilWQz+69ASgB3y55CnXr/r8r5T/uPW
-        H5zjLOyRZl91sJQEQ/qv1z7DnsgWGGDOBCc8AlveVx8MZAJZZLzWhbYV9IVT
-        lok8Cox3tQeLy6AXFIptxvlUwht0mjLKYzjV21MeypyRyMNgPZ8r+94nnsnT
-        tq6Vc9MKPFoz4cM143EUHA8sCBgfchaYD79aG4YO69gewznglxfjJxUA8niK
-        +cG7W49003p//DWm6z+8ntz9D5FCYkaJOwAA
+        H4sIAAAAAAAAA72SsVLDMAyG9z6Fz3OuocDQy8bOADPHoDYmFahOTpYbcr28
+        O07ShBh6nSiT9Euy/+9kHxdK6Z2BXKtMHYMI8gDsOvmiNJkCHYF4NjqJ5CNs
+        DHW1d8/octwKlvannoa2pbfCzSydWs6AuC6pgGWMQ1e9BqA26RDZOE/iZpQb
+        tDna4kQ6FFVMPA33HWmqvqQDoE6+6wcgPzR2IlWWpnVdL2v8wBwEliUXqbGC
+        0qTPd+vb1WqtT0fb8Y54BX9ten9zxnHc57+Y/Xr12PVzTxmBLXoDY+fGExCh
+        GAY6D/UETAj7wKDKN/XgnYRRhMt7vgrJBe/o217dto/t8P8X7RfRMnw7pQMA
+        AA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:43 GMT
-- request:
-    method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q39%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Host:
-      - query.wikidata.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 21 Feb 2018 07:16:44 GMT
-      Content-Type:
-      - application/sparql-results+json
-      Content-Length:
-      - '327'
-      Connection:
-      - keep-alive
-      Server:
-      - nginx/1.11.6
-      X-Served-By:
-      - wdqs2002
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - public, max-age=300
-      Content-Encoding:
-      - gzip
-      Vary:
-      - Accept, Accept-Encoding
-      X-Varnish:
-      - 138567632, 250711789 231585740
-      Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Age:
-      - '216'
-      X-Cache:
-      - cp2006 miss, cp2006 hit/1
-      X-Cache-Status:
-      - hit-front
-      Strict-Transport-Security:
-      - max-age=106384710; includeSubDomains; preload
-      Set-Cookie:
-      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
-        25 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
-        00:00:00 GMT
-      X-Analytics:
-      - https=1;nocookies=1
-      X-Client-Ip:
-      - 121.44.11.137
-      Accept-Ranges:
-      - bytes
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAA7WTTW+DMAyG7/0VUXZF5UulGleu7WHaZdq0QwouWAsBhaSs
-        qvjvCx+isKJph/Zk7Nh+H1vmsiKEZsASSkJyMY5xT0xWrftBKCrIqdXbHTsA
-        b52yKDVnCgvResXxiDFcv8a0rutgxyCHFCtTrCX8cvsU8mkYGqulklBprqoJ
-        2AFFgiId4PogGSDHrC6kziW0IaolUusaPzGu+4dMqTK07bqu1zV+YcIUWxcy
-        tUEoVGf7ZevRoayxpkID5kztO+chZyLtGoOYCo4g3BRLxpdh3g1mnN0KTjY9
-        V2xxx9bTUfxuCM9xXPttv3uNM8jZUwIx5nPt/3H5z4HjbW+55gdzp427nu8H
-        /rLYQ7YeFRIFkD3TS7ufXuq9R/XcjRs4m+2fqg+8NBIZDBIVWsTIR4jONv0f
-        uGp+AJQA6YYaBAAA
-    http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:44 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:23 GMT
 - request:
     method: get
     uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?item%20?itemLabel%20WHERE%20%7B%0A%20%20?item%20p:P31%20?statement%20.%0A%20%20?statement%20ps:P31%20wd:Q160016%20.%0A%20%20MINUS%20%7B%20?statement%20pq:P582%20?end%20%7D%20%20%20%20%20%20%23%20no%20longer%20a%20country%0A%20%20MINUS%20%7B%20?item%20wdt:P1552%20wd:Q47185282%20%7D%20%23%20not%20free%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20?itemLabel%0A
@@ -787,7 +543,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 21 Feb 2018 07:16:45 GMT
+      - Wed, 21 Feb 2018 07:19:24 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -807,15 +563,15 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 138660699, 261370077 163931713
+      - 139020127 138244698, 245785897
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '372'
+      - '158'
       X-Cache:
-      - cp2006 miss, cp2006 hit/2
+      - cp2006 hit/1, cp2006 miss
       X-Cache-Status:
-      - hit-front
+      - hit-local
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
@@ -871,5 +627,249 @@ http_interactions:
         3hq921v9aScVWtSOeNLvu8i/bNUA4YOUXCJ768IAiUIJ+piSd2KCeDxXaEba
         k/cyxCPLUBX0Xrdzma/xYHtOSh/5j6fTRx+e7f7/8hc138BunoIAAA==
     http_version: 
-  recorded_at: Wed, 21 Feb 2018 07:16:46 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:24 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q39%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?country%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:19:25 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '342'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 93712755, 241997030 98399249
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '163'
+      X-Cache:
+      - cp2018 miss, cp2006 hit/1
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7VTy26DMBC85yss9xoFSKrmcasq9ZQeqlwqVT04sJBVjUHG
+        htCIfy+G1EASRaqUnOzZ18yY5TAihO6ABZSsyKEGNcyZzAz8JNRPtFCypGN7
+        XbMtcIPTJNWcKUyEQbAHXyvMYQBsMYcIs7paSziBtqQRcTxtMAlD9KG7tQny
+        VQutxka6hExzlfXUb1EEKKKjgzZIOie2sImqMgUToloiHXfxnHHdJnZKpSvH
+        KYpiUuA3BkyxSSIjB4RCVTrvsyU9tlV//QO3t+Z7WjzOvQucvc8xpDQTLG1/
+        +qyZO3Vdz/l4W2/8HcTsIQAfY8b72mwzRwVymOt0L6aeN3fdc2HdZtz86d2l
+        Nz8nHCzqkHMf8xVnImrGg/i/y02B6gdkPSO44vQu1K8QmCR5qe35yK9u3V0F
+        PGcZxFtekiQkl96jOav2Hx1Vv2zHMGhhBAAA
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:19:25 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:19:27 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '1062'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 212830252, 250711833
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2012 miss, cp2006 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1bW2/bNhR+z68Q3Ncs5lWU8tYWbbAh2TqkG4oOe6Al2iZK
+        UwYlxUuL/LO+9Y+NvsCVLadpi/iQQPtkk5bIc/h950bSH06SZDBVshwk58kH
+        3/DNG+nqZfOfZKAbNRucrj8v5UiZZWNezVsjG13ZZasaj3WhPn/bPrYadfO5
+        7TRqomv/cuvUXnP9SPKvl+HudCmVU3Vrmroj2EjbUtvJRrh1Z7IRcvvUqqu5
+        natl16B1enD6uf9Gmnb9w7Rp5ufD4WKxOFvod7qUjTyr3GSobKOb2+GfGOeM
+        DjZv3p1259pIujPhfzNzbqSdrMZWtjvnVhbjX3bSHJbnubRNZZNqnLz99NHp
+        Ytqfu7Puu5Mvhd/O0lWMrlQiCOHhm6vL62KqZvJJqQo92xXj60TEDGVc8L5g
+        u/x5NABSlt4z2VEQuJJOV8lLNXX9Sbu0fWxFCcYIIfLFSY9IOWmS51VrC21W
+        5Gt3uHeylujYtkYYDWNr3iQWt+8jNDXOs5TC8hALkmGE4+DhHjBQPBQsDcPD
+        5iy5kMb4UaLjouCcZsAuEWUkxSwSKkr7rtlHB4iQOCckCCEvjHRtHR8ZmQ+V
+        CNgvYiYoDUDGS2lLJ5sDcPxk34/DPkoo4vk3s+/rFOoNDxVouYBM+P4YLaQp
+        YwyuVFCRwed5KM/iCK49ZMAqDsQACfiXFzQ+7vkUiwNzj2SCP+BCjx1Lu1hA
+        sc3bHCDbnslamV+uG1k2sPCmAuU8gGe5cB7erls5tAJgWAeqIdc6L4leF1M5
+        BoYeZ4imGQ9q2feuAFi+jHEY6JWzUNuyxLvwDHBb9pmSjdOFSq71rLLA/ixl
+        nIkY/FkXYChHljIUhM0vnR5VrZvAY/0dddbjY91TH857iTDVvrLqRsKizX0F
+        lJMI0N5THmyjm/MgWP/WOmCkCfW8xgFKjlfSGS1nXo6e4mCpKAmTj1y2hQ9Y
+        ChhoQQnCIo59jf0VAIvZuQh1kCrH46lsa2VDHFuiaI4t+8sAt1ufh8G+MlUz
+        bR0w8CQVGReR2Ht/DWBQzygLgvnf0khdAwPusxb2wK0ImKRtT3uwpE3gQGC3
+        JfSdKIoFQ1FA3dEdzJMHug71tgUuunHOMk4i8eFd7WGQpr4KhUT6RT2XhUqu
+        dNMo40cKwGwCWXd6a25Hnz7aEjwpzRilWQz+69ASgB3y55CnXr/r8r5T/uPW
+        H5zjLOyRZl91sJQEQ/qv1z7DnsgWGGDOBCc8AlveVx8MZAJZZLzWhbYV9IVT
+        lok8Cox3tQeLy6AXFIptxvlUwht0mjLKYzjV21MeypyRyMNgPZ8r+94nnsnT
+        tq6Vc9MKPFoz4cM143EUHA8sCBgfchaYD79aG4YO69gewznglxfjJxUA8niK
+        +cG7W49003p//DWm6z+8ntz9D5FCYkaJOwAA
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:19:27 GMT
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q39%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:19:28 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '327'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 138567632, 241997033 231585740
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '381'
+      X-Cache:
+      - cp2006 miss, cp2006 hit/2
+      X-Cache-Status:
+      - hit-front
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7WTTW+DMAyG7/0VUXZF5UulGleu7WHaZdq0QwouWAsBhaSs
+        qvjvCx+isKJph/Zk7Nh+H1vmsiKEZsASSkJyMY5xT0xWrftBKCrIqdXbHTsA
+        b52yKDVnCgvResXxiDFcv8a0rutgxyCHFCtTrCX8cvsU8mkYGqulklBprqoJ
+        2AFFgiId4PogGSDHrC6kziW0IaolUusaPzGu+4dMqTK07bqu1zV+YcIUWxcy
+        tUEoVGf7ZevRoayxpkID5kztO+chZyLtGoOYCo4g3BRLxpdh3g1mnN0KTjY9
+        V2xxx9bTUfxuCM9xXPttv3uNM8jZUwIx5nPt/3H5z4HjbW+55gdzp427nu8H
+        /rLYQ7YeFRIFkD3TS7ufXuq9R/XcjRs4m+2fqg+8NBIZDBIVWsTIR4jONv0f
+        uGp+AJQA6YYaBAAA
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:19:29 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryCities_Q191.yml
+++ b/t/fixtures/vcr/CountryCities_Q191.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q191%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q191%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 08 Feb 2018 03:54:13 GMT
+      - Wed, 21 Feb 2018 07:13:22 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2001
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,26 +41,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 249739332, 72300847
+      - 93895487, 245785734
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
       - '0'
       X-Cache:
-      - cp2012 miss, cp2018 miss
+      - cp2018 miss, cp2006 miss
       X-Cache-Status:
       - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=08-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Mon,
-        12 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=08-Feb-2018;Path=/;HttpOnly;secure;Expires=Mon, 12 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 121.44.141.17
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -74,6 +74,6 @@ http_interactions:
         hr227Inn3svd2MM+nhmzzM/X/XuQ8BSeQh5guja/Dcxxdsx1z7mmY7/32G3P
         YS676veQ2afQZIpkEbl6COsHcq8btnOYbTnOZbsH3TKokLxAMXsOsR1f3ab9
         Az9XQEgOBAAA
-    http_version:
-  recorded_at: Thu, 08 Feb 2018 03:54:13 GMT
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:13:22 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryCities_Q30.yml
+++ b/t/fixtures/vcr/CountryCities_Q30.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q30%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q30%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -21,17 +21,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 09 Feb 2018 03:46:39 GMT
+      - Wed, 21 Feb 2018 07:13:02 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
-      - '3225'
+      - '3276'
       Connection:
       - keep-alive
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2003
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,103 +41,104 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 223118559, 76026938
+      - 138567542, 261186667
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
       - '0'
       X-Cache:
-      - cp2006 miss, cp2018 miss
+      - cp2006 miss, cp2006 miss
       X-Cache-Status:
       - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=09-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
-        13 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=09-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 13 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 121.44.141.17
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+1d23Ibtxm+z1Ng3FtVxvmQO1OK7MiS40qauJlOLiASIjEE
-        ARW7K4bN5GH6AH2KvFixEqPQDd1kPNp/Ma0uLIk0SYDA//3nw49fIPRi4ezs
-        BfoS/VgelId3Njf9w7+hF751qxcHD7/P7LUL/YPbdNsF2/oU+0fp5sZP3a9/
-        Pb7s/lO3vx+fDG7um/LmLrv/ePjwEvR92cNPB/2usmu60DY7G7v2cebjfLu5
-        hyfRdpOPr7p/qt3cuv6pF132Lw5+ff7Ohu7hPxZte/vly5fr9fpw7Zd+Zlt7
-        mPL8pYutbzcv/yLxi+3bfjrYXWi7zY9W+2EVvgw2zu8/2MXdBR83Esqbsw37
-        N/POrdF3KS/RUVn7t+vuHPjHC/e7flxh9xux++9CMSYv/3p+djlduJX908xN
-        /erjLfyx7WnBlFTstxvb3v1Tn70qC2L+qeUGuYFzu0kZpRv0O1fxMVSe6Pty
-        Qwg3av9qg3zdiQ8BzRyaBNv49NuFd2H65MjighjxX9ccHmToKHVx6sPjNr54
-        2MzQXEUAcpWz1KBXce6Ca+rjKcwoySgFQphgWgoBibCvsp+i1zZPXdt6WIAR
-        rTDnCh5hOwT3DLJnkP1Pg0xKTTFnI4MsrVYpjgQzQvepLIMB7Wjhp3ae6gMZ
-        VZQybYBARo3m+8huMIxd2MUKfbWysXMBFmLUSMYwgYfYltTGlGGkcFJIMfYm
-        dU1bEFQfuoqtYAgHQheRShCiJSC+LjfhzjXlBeiqy9FlWIyVs5WcaniMbQlu
-        VIwxDgmx9wsf7MyF24W39eGMCInpp3wQT689EcbkPhfbYDA7tauiMJ0corcu
-        RrcZgZ1LUFpLLvofKiQzLg1XBMyVSJnsCVuM40z85DUMY39JLOmnFNFBvujr
-        7ObosrVxr+owpNxSRUhrguHl1vZKx5RbRkGKrUsbi71ZLthXaHsRXsQImNQi
-        StHeuQaIsK/vNujKbkLKI0gsCkxmx97VaOATZrjZpyMPoxoxI6mA5OJv3Z2P
-        6MR2YZp2DRA4QoP0Ix3bEGyFvlpCjNJEQlGZ5loQCkhl537p0IVdh/sIPqyR
-        SwmhZgRf7QOtje1HYsBs/DQ1rkJ8FSuACQxmeTBMNKzZserNDjhHGSNcE0hH
-        mV2hMz+d2jxLwCjiWql9CSkDumNjCl3o7rlGjSlBRjNODRiYCFGUSkPGMeN/
-        uQ3gML40GjPFx/DN/kJ94wouA4i4V13T+grjH4ZQtUP3QPzOMIkhnQzHXfm7
-        WmantdA70TgwAEgNeAWndrpsUrzzIVSovWmNJQGLsROMBQeNAp65GAur7XKG
-        Dk1IxiEjE1/HmbfR3qbgKzTCtWBEMSgbvNAZk5A2+GlyRZmZN65tRxDnkNzs
-        JOUWfSg/FhUSGekThqBhDu3MPcm2qI3NtEKHrsaCMgFXzmAENSNFIH/nJobh
-        a7JYLhoySnKW4ixFNMnOzWCNNCaFVvtC+0PbaB9dLJokm2f3993dunznm5Sb
-        EfRV0HzQYqKurrsKlQilFWbs2dH4NGRlDNNUaUBu8irOsluj1z62C/BwWB/Q
-        1qD1C51vKjX6lMSYyhH4mADNa7c5pLat8fwZ4RQq9VZQoiiBtLmPbfQuoNeH
-        6Cik2Y0L7TPax6Q2TATG4EUsnEG6mY9dm5Nv6zt9qTEVGEqoC2mMZhI6/eC4
-        m89thE4+6E2EEaoxt6Q2ZhCHMgJaI/bONotKuVvh82xfTe6zUfBZOhqRXBHI
-        JLlzVzgHmtgRHPQEEEEfCoJ8nLcpHqDjw6PDCoEktDZw1rUgBgtFx/HeFfsT
-        HfumzX7a9o8ffB77yoeGceQV01uA9iU5L3stKvkkrRvoSjgpqNpbxjt4temD
-        aP5D9w2kFGPI5keTVGflaR+x0mCFp4JQyT613EBcJhfF8IMNzQIWadxwpfEI
-        NacPlDZ2VhMHNTfj3T5GOjq2Cg0Y8awNP1EuP8OGEVBjerqwRU6/sXGapssR
-        PLSQ0eyvAnpvmwrj2AVFZCfQBHf6kBUF5251u6gxV0hyqeHavlCsmDSQYbBT
-        v0KXvSq6LB8zA6YygQ0kxCc2tH6Vco2OI0oJhlJDGTeaS9D2J627XfSBmMfa
-        sD9Pgl06YJVUCzpKOfkj4Y2plQqsQWvEnG3bKn20WH+yKckATW4xoxzSuXJV
-        GPqky3PXANdfKs6L+BrBtbKltDGxxdTeONdw6pIPa9stXZXwwmRfU7NB4GVE
-        sbQhc6uv0uo+PACfW824BtXIvykK4SKtbKXdyoUhRoK1BCm7ZoWRwxrfy8LM
-        coSnNEkwaBerlNuPbI96aEwzpaB6Nag+DiMhXcNXboY+LJwL4AlRlCnYhCjb
-        oG/dvMaGID2NCQmXZiuUoZBEdmRzCpuIXqc0W+1k5YAJTdCK/lfhuvt753L5
-        VyGpcaEFBXPHS0kVxyMV8++7CCDPqRagnduuumlTY2BVUEz2Jfo+B38+B0sF
-        SrDlEacp2nZhI7pI7aKZLnyYgWdN720LPlwxaXZNrDD+ww2XEsqgploQzgQH
-        LYp3aJLhgw9EYwLbNGua7aqsXiONlWs3YFGuYkmDtl14aH14mhZxV1JCBVIV
-        aOnBWYpzNHF2WmFJPJeU7nSBBBIjRBPIC3hrY7PtBljhDQijNJTXTAlOOWj6
-        9mXYoPsW8OCdlChoG6tvfZ776G21QOeaKyhxonvfLGiPwg/9XMVL1zRp1YB7
-        zmBHDLzqXbNthZMsOFeak2fz8om6QykuGGg3atv4FboA7+TBNZGYj5ACsgXS
-        mEFqTrCGrNO7sMH5eY3iiRltwHpwG0n3cqrBsPXOxukGnU9PbC6f4+B1IdBa
-        tnPX1CiemMEcuqEnUZhD5lN+Y5d1Bm45pVpI0EiHZGacSMf2Eg7QkQ3+JuUI
-        VzgoOOYC0il95q+vN6hQh7U3wNjSEnRQyrm3K18hsIiSYP0juCyo0rDJXT//
-        syla6dwGC99+3lDQ5plHKaRcvia6vM37p3WMT22SU3B/IdvrCR9OiK7sokYF
-        Bmuzjxyf7evPUcyYkJRj0EmYzkZ02aa+uV0LnAheSIfvmzo0tI19D6VR08Al
-        NqC2j4/R1dplu9A7Vs+TeNATxeUpZpLBztKdpmt0kt0GuEWHlsqoEdjHDprG
-        rSVhFLIzx1Fwd65OO54ZqQlU6ks/C0IxyFKtvrPzsu9MuZ3KAdyyjhQ6MyPg
-        7JHgRnWGc6MNaJpmqNFPyQwxWII1fy1wBu1+c+zWbtPPg5/Y3AbXtgfoNB/C
-        J5qZMcbK1UhtWDH9fz9PbhhvLCeCYwYZw/V52XudZ2sXwghRJsg8iA9+uvA1
-        5kEwTZmEmlotMDMGNE/gyObQT/xYg9eoMc5BS4feuTX6JgdnY4W2PFNagSni
-        jBGFJWjbV99OF+isqKTZuw48ams4ZB76qxweer9WSGZScPCZWZxQQqCHZ3e2
-        xuMXAu+bRPvssfssWcmZJApWVq5cRN914ed/RXSUu3+MEMEELX20q9saVTKu
-        JBcjnL0E7aW2dLm58S7U6DfkimuoAZ9CKgXb4umNzXdug97YHbMLKHu2kNk+
-        nj18A7VHahvVaWj2XvRwqlq0C+dXFQKMSQpWk0qkYUyDt3m6sr4dgb5Aqzu6
-        nHKNEpQWRVSPcPgc1g5oLSoQr/H8uaDQ5880pqDji9tDdD8prcLzJ5oTCZZa
-        YAiRFJK9nm1mFr3Nbg1fj92jnIJmWebbrkFHi+ybtsKMXkYk0+CFCgz0Dt77
-        tm2uu1xjLRLDArKOkRjNdRGu8G6XPiS25yLgUA/pY73wd8Ve8bMKu4AxzLSC
-        BjwzXGBQw2m6KJrtvMrzx0bgEZLaIQ2LI1+s8xhtjRKPGrk34DJQ4y6qBIZt
-        3LXonb82BrcZgctCRlLO3A+1RrKoERqzEc4fg1pQabqs9Pgxxwb++EFbPV2l
-        4GYVNhOjWlEM7T2guii2oN4bH1v03nahxgsQGCwniGClyKdyQ4ZRLnpbup+a
-        6eAbClPBjIDNCrJ5WSOJEcOh5hUpargEbaFxYZs+ZdguLTgboxJShJ8VRT2F
-        GiV4UZ8kh+Nh0hgKzsMmrmsD9AhkRgSX+2ZrDx3EnfaB2+lYgVsGqR28zs7F
-        5jrlGtUzZSQzYLFbLLHSDLz90be2my/A1QNBJGhV0fvy7hpJTJrdwSlAGMec
-        Qapmk+7mxoYaT19oI8AATgkmBrKma7LJKaJJTusRYocSMv3njYszl6uc7kCF
-        Klr5CFJcAmcIvHflBfcxqxovge0qcnAggFSlTlJu0Qe7iRXGcu4vgMBfAGhD
-        86/zna/z8DHbKSZ+OHz0/Rf93z/9G2ASmkfyzgAA
+        H4sIAAAAAAAAA+1d23Ibtxm+z1Ng3FtXxvmQO1OK7MiS41qauJlOLiASIjFc
+        7qrYXSlMJg/TB+hT5MWKlRiFbugm4xG/xUx1YUlLk1ws8H//+fDTF4Q8WwQ/
+        e0a+JD/li3x541M7XP6DPItdWD17fv/71F+Gari4bq77ynexqYer5uoqTsNv
+        fz287e5bN78fXqzCPLb5w30K/3V5/xbyfV7Dz8+HVaXQ9lXXbi3sMtazWM83
+        i7t/kWwW+fCuu5e69XUYXnrWp/js+W+v3/iqv/+PRdddf/nixe3t7cFtXMaZ
+        7/xBk+YvQt3Fbv3ib5o+23zs5+fbN9os86O7/bCqvqx8Pb/74lBv3/BhIVX+
+        cPLV7sW8DbfkuyYtyWG+9+/vu7XhH994WPXDHbafSNw9C6eUvfj72en5dBFW
+        /i+zMI2rj5fw55ZnlTDaiN8vbHP2j733Jt+Qyk/dbi8ncObXTSLNFfmDo/gY
+        Ko/0vNIxJp3Zfbe9PO4kVhWZBTKpfBub3994G6aPjiypmFP/8577Bxk5bPp6
+        GquHZXxxv5h9cxUF5CqnTUte1vNQhbY8niKc0YJzEMKUsFopJMK+SnFKXvk0
+        DV0XsQBj1lApDR5hWwQ3JsgY38VL9wazw0Wc+nlTHsS44VxYB4IYd1ZKAUTY
+        e79Yka9Wvu5DhQUYd1oIyvAA25DaqODKfBQpxF43fdtlBJWHrqzEOCZB6GLa
+        KMasBuLrfF3dhDa/gVz0qQ4Ji7G8t1pyi8fYhuBGxZiQSIi9W8TKz0J1vYi+
+        PJwxpSn/lHH0+Ao6E0Lvsv33BrMTv8rq0vEBeRPqOqxHYOcaSmtNqOMPBZKZ
+        1E4aBvNxcKEHwlbjeDk+eQz7sb401fxTiuheHvRVCnNy3vl6p+qwT7llspC2
+        jOLl1uZIx5RbziDF1rmvs7WZDzgWaHsxmcUITGoxY/hg9QMR9vXNmlz4ddWk
+        ESQWB5PZUQwlGvhMOOl26cj7UY2E01whufibcBNrcuz7atpsGyA4QkP6kY58
+        VfkCPbWMOWOZRlGZlVYxDqSys7gM5L2/re5Ci1gjlzPGncArC/e0NrYfSYDZ
+        +EnThgLxla0AoSjM8hCUWazZsRrMDpyjTDBpGdJR5lfkNE6nPs0aMIqkNWZX
+        pHyP7ti6qfqqv+MaJeYqOCskdzAwMWY4146NY8b/ehrg+KJ2lgojx/DN/kp9
+        4wouB0Tcy77tYoHxD8e42aJ7EL9zQlOkk+Goz38Xy+ysVXYrGgcDgLbAIzjx
+        02Xb1DexqgrU3qylmsFi7IxSJaFRwNNQ15nV9imhQxNaSGRk4ut6Fn3tr5sq
+        FmiEWyWYESgbPNOZ0Egb/KQJWZmZt6HrRhDnSG523KSOfMg/FgUSGRsShtAw
+        Rztzj5PPamM7LdCha6niQuHyrJ3ibqQI5B+cxH74mtFGGYn0Lfq0JMc+pVCB
+        c9SEVtbsCu3v20b76GDJpPFpdnfe/XVIN7FtUjuCvgrNB80m6uqyL1CJMNZQ
+        IZ4cjY9DVs4Jy40FcpOX9SyFW/Iq1t0CHg4bAtoWWr3Qx7ZQo89oSrkegY8p
+        aF67T1XTdSXuv2CSo1JvFWeGM6TNfeTrGCry6oAcVs3sKlTdE9rHpDbKFKXw
+        IhYpkG7mo9ClJnbl7b62lCuKEupKO2eFRqcfHPXzua/RyQeDiTBCmdiG1MYM
+        4nDBoDVib327KJS7ZT4vdhULPhkFn6WjMS0NQybJnYXMOcjEj+CgZ0AEfcgI
+        ivW8a+rn5Ojg8KBAIClrHc66VsxRZfg43rtsf5Kj2HYpTrvh+t7nsat8aD+O
+        vGx6K2jDhLO81qyST5rbFl0JpxU3O8t4915tei+a/9R5g5RiiuzKMmnKrDwd
+        IlYWVniqGNfCgp3mWTH84Kt2gUWadNJYOkLN6T2ljZ3VJKHmZn2zi5GOjq1M
+        A049acOPlMsvqBMMakxPFz7L6de+njbT5QgeWmQ0+6uKvPNtgXHsjCK2FWjC
+        7T6youAsrK4XJeYKaaktru0Lp0ZohwyDncQVOR9U0WX+mhmYyhR1SIhPfNXF
+        VZNKdBxxzihKDRXSWamh7U+6cL0YAjEPtWF/nVR+GcAqqVV8lHLyB8IbUytV
+        1EJrxILvuiJ9tNR+sinJHrpvUsEl0rlykRn6pE/z0ILrL42UWXyN4FrZUNqY
+        2BJmZ5xrf+pSrG59vwxFwouyXU3N9gIvp7KljcytvmhWd+EBfG61kBaqkX+T
+        FcJFs/KFtlFWjjkNawmSVy0yI8ca38vMzFKNpzTNKLSLVZO6j2yPcmjMCmNQ
+        vRrMEIfRSNfwRZiRD4sQKnhCFBcGmxDlW/JtmJfYEGSgMaVxabbKOI4kskOf
+        mmpdk1dNM1ttZeXAhCa0ov9lddn/sw8p/yuQ1JTjBpecojU3ko5UzL/rIEAk
+        J6RkDkl0b4cCuODbjpTdfFRxu+19ATmyrYI20rvop22JcW7FKduVd/0Ui/sc
+        1pY5G7Za5aSpfbfwNXnfdIt2mnE+gyex7+zSvr/a3hTausBwnHRSa5R/g1vF
+        pFAS2qMgkEnCx4KYpQzbw2ya/CrfvUQay8fuYEFHKji0C8Z9J8qTZlFvS0pU
+        XNtAK0FOm3pOJsFPC+xQIDXnW005QWKEWYY8gDe+bjfNGQs8AeWMRTkxjZJc
+        QrPpz6s1uevID29sxaFdxb6NaR7r6IsFurTSoMSJHVzl0JaRH4b5e+ehbZtV
+        C3dkYic+vBw85V2Btr2Uxkr2ZF4+UrMuI5WANgf3bVyR9yHM0Bk5TFM5QkbO
+        Bkhj5gxIRi2ybPK9r0KclyiehLMO1hLdab6TU+0NW299PV2Ts+mxT/l7Al4X
+        gpYWnoW2RPEkHJXo/qrMUIlMb/3GL8uMo0vOrdLQwJMWbpzA0+YQnpNDX8Wr
+        JtW4Ok4lqVRIp/RpvLxck0wd3l+BsWU1dG7NWfSrWCCwmNGwdh5SZ1RZbK7d
+        L/9qs1Y695XHTwNwHNrL9LCpmpQfk5xfp93DU8anNi053F8odnrC9ydEV35R
+        ogJDrdtFjk/29ecoZkJpLil0MGnwNTnvmqHXYAfOy8+kI3cNgdq3jX0HpVGz
+        8jV1UNsn1nUotel5pndqngYjkUeKy3MqtMCONp42l+Q4hTW4Y4rVxpkR2McW
+        msYt7REc2SjlsAo3oUw7XjhtGSr1ZRjNYQSycm5otL0cGoVuhqSAOwiyTGdu
+        BJw9ENyoznDprIOmaVYl+imFY45qWC/eDGdoM6KjcBvW5PhgKKHrqtB1z8lJ
+        OsAnmrkxpvyVSG3UCPt/P95vP95YyZSkAhnDjWk5eJ1nt9vzMVCYAhcNnjd9
+        tyg13ybjilk9QqAPeQIf4nQRS0xFEZYLjZrjrqhwDpqqcehTRSYpS9IEL6aT
+        0GK6t+GWfJOq4OsC3SnCWAOzhYRghmpoI+TYTRfkNFsFKYYeHjh3ElkK8DJV
+        992QCyQzrSR8ipxknDHwILmT3pe4/UrRXTPOnpymnyUrpdDMYGXlKtTku776
+        5d81OUz9jyMEkaHVp351XaJKJo2WaoS919DugsuQ2qsYqhJdt9JIixp5q7Qx
+        2KZnr326CWvy2qMnQ0qbyWwXz95/S8EHahvVb+t2HvT+VLXaL0JcFQgwoTms
+        LJhpJ4SFNz678BE+Udq6nQrY/ry12bwORdKXYtSNgG5oeVOfmlSi/sKzGWBH
+        2HyJtcI6TzKDLXH/peLo/ReWcug49e6A3E1uLHD/mZVMw3JrHGOaI4Xb6Xrm
+        yZsUbvENCQaUc2iacbruW3K4SLHtCkxpF0wLC6/UEdAzeBe7rr3sU4nFeIIq
+        ZCEvc1baLFzxTq8hJrzjIHCoR3q438ebbC3GWYFdCQUV1qABL5xUFGq2ThdZ
+        s50Xuf/UKTpCVQfSsDiM9TTWtS9R4nGnd4a79tS5jhtFsZ3rFoPr3ddVWI/A
+        ZZFxrNPwQ6lxRO6UpWKE/adQC6qZLgvdfirH8N5Ae51dNFWYFdhNj1vDKdp7
+        wG1WbKHem1h35J3vqxIPQFFYRhajxrBPZebsR7kYbOlhim/ANzjnSjiFzcny
+        aVkiiTEnUfPTDHdSQ3vIvPftkDPvlx7OxrhGivDTrKg3VYkSPKtPWuJ4mHaO
+        w3nYJPRdhR7JLpiS2gl8CH06hM2nY4XNBVI7eJVCqNvLJpWonhmnhYNFzqmm
+        xgp4/69vfT9fwNUDxTS0rO5d/nSJJKbd9iAnEMapFEjVbNJfXfmqxN1X1ikY
+        wDmjO8ev7A3fk3VqajJJze0IsUONTL56HepZSEWON+HKZK0cvf+GawEdqvuy
+        iuGqxN3XaktdxelQGpyf8S7kN9xFDEs8BLGtRuNYEFKRPW5SRz74dV1gJO3u
+        ABj+AKDzFL5ON7HMzadiq5fB/eaT778Y/v75P50o//uZ0QAA
     http_version: 
-  recorded_at: Fri, 09 Feb 2018 03:46:39 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:02 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryCities_Q801.yml
+++ b/t/fixtures/vcr/CountryCities_Q801.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q801%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q515%20%3B%20wdt:P17%20wd:Q801%20%3B%20wdt:P1082%20?population%20.%0A%20%20FILTER%20(?population%20%3E%20250000)%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 16 Feb 2018 02:03:14 GMT
+      - Wed, 21 Feb 2018 07:13:25 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2002
+      - wdqs2003
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,26 +41,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 138875041, 222479898 189456378
+      - 18483230, 261186675
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '242'
+      - '0'
       X-Cache:
-      - cp2018 miss, cp2006 hit/1
+      - cp2025 miss, cp2006 miss
       X-Cache-Status:
-      - hit-front
+      - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=16-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
-        20 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=16-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 20 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 121.44.5.211
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -80,5 +80,5 @@ http_interactions:
         MjZk5MkQPGGu5yNPkCfIk7MqTf1Tby1dDCg3IJfw/mDi8CC02Vi3X8ap54Yj
         Hq/7NAFyD2sosV291S+s6h52iO0K29X/3K6aF5Mnuz8rMMTZMS0AAA==
     http_version: 
-  recorded_at: Fri, 16 Feb 2018 02:03:14 GMT
+  recorded_at: Wed, 21 Feb 2018 07:13:25 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryDivisions_Q1029.yml
+++ b/t/fixtures/vcr/CountryDivisions_Q1029.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q1029%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q1029%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 05:55:07 GMT
+      - Wed, 21 Feb 2018 07:19:30 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -31,7 +31,7 @@ http_interactions:
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs1003
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,26 +41,26 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 85726887, 89574995, 83986642
+      - 212294626, 261340154
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
       - '0'
       X-Cache:
-      - cp1061 pass, cp3007 miss, cp3008 miss
+      - cp2012 miss, cp2006 miss
       X-Cache-Status:
       - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
@@ -75,5 +75,5 @@ http_interactions:
         tAgsEt+BpHdnA55Gi3AeW8Utaq2cTndmEfce8vYgcMq7sMlLUFUucePJhUXc
         J7UCh9OdzKPY5t/5GTU6ne3UIuyLOYhwR/9Ot7uGjQ5fpk2OtB8KAAA=
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 05:55:13 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:31 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryDivisions_Q191.yml
+++ b/t/fixtures/vcr/CountryDivisions_Q191.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q191%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q191%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 05:55:59 GMT
+      - Wed, 21 Feb 2018 07:19:34 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -29,9 +29,9 @@ http_interactions:
       Connection:
       - keep-alive
       Server:
-      - nginx/1.11.13
+      - nginx/1.11.6
       X-Served-By:
-      - wdqs1005
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,28 +41,28 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 141570636, 16579995, 83921300
+      - 212895877, 250711842
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Accept-Ranges:
-      - bytes
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
       - '0'
       X-Cache:
-      - cp1045 pass, cp3010 miss, cp3008 pass
+      - cp2012 miss, cp2006 miss
       X-Cache-Status:
       - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -80,5 +80,5 @@ http_interactions:
         W82Akguci1iA2Q6moFJ7EXhxzDk6AhpRhvqidlAWl4EXchZhM+BBwFHr4FZK
         i9+V/ehlR26/Jg92fwGQxVgr5hYAAA==
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 05:56:04 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:34 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryDivisions_Q39.yml
+++ b/t/fixtures/vcr/CountryDivisions_Q39.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P194%20?legislature%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q39%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.3.3p222
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Host:
       - query.wikidata.org
   response:
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Feb 2018 07:25:33 GMT
+      - Wed, 21 Feb 2018 07:19:32 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
@@ -29,9 +29,9 @@ http_interactions:
       Connection:
       - keep-alive
       Server:
-      - nginx/1.11.13
+      - nginx/1.11.6
       X-Served-By:
-      - wdqs1005
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,28 +41,28 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 1591078, 157896492, 80770120
+      - 212830252, 251956864 250711834
       Via:
-      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
-      Accept-Ranges:
-      - bytes
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
-      - '0'
+      - '5'
       X-Cache:
-      - cp1051 pass, cp3008 miss, cp3008 pass
+      - cp2012 miss, cp2006 hit/1
       X-Cache-Status:
-      - miss
+      - hit-front
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=20-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sat,
-        24 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=20-Feb-2018;Path=/;HttpOnly;secure;Expires=Sat, 24 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 94.173.239.224
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -91,5 +91,5 @@ http_interactions:
         tq6Vc9MKPFoz4cM143EUHA8sCBgfchaYD79aG4YO69gewznglxfjJxUA8niK
         +cG7W49003p//DWm6z+8ntz9D5FCYkaJOwAA
     http_version: 
-  recorded_at: Tue, 20 Feb 2018 07:25:38 GMT
+  recorded_at: Wed, 21 Feb 2018 07:19:32 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryDivisions_Q408.yml
+++ b/t/fixtures/vcr/CountryDivisions_Q408.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20DISTINCT%20?item%20?itemLabel%20?population%20?office%20?officeLabel%20?head%20?headLabel%20?legislature%20?legislatureLabel%20WHERE%0A%7B%0A%20%20?item%20wdt:P31/wdt:P279*%20wd:Q10864048%20%3B%20wdt:P17%20wd:Q408%20.%0A%20%20FILTER%20NOT%20EXISTS%20%7B%20?item%20wdt:P576%20%5B%5D%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1082%20?population%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P6%20?head%20%7D%0A%20%20OPTIONAL%20%7B%20?item%20wdt:P1313%20?office%20%7D%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?item%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0AORDER%20BY%20DESC(?population)%20?itemLabel%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:19:35 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '880'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2002
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 138920091, 231585830
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2006 miss, cp2006 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2aUW/aMBCA3/srLPaySajEduw4fVuZtHVru1at1knTHlxy
+        gFfHQU6Aoar/fQ5ElBaoNqkxkcZTsOPkzr77zncO9wcItYYgkxY6Qveu4ZoT
+        afOy+QO1VAFpq724nspb0GVjlI3GWhYqM2Ur6/dVDx5/LYfN31pdl50aBip3
+        D48tPGsuhqCfToeHdqmVhXysi3xFsVtlEmUGlXKLTlQpuRw17ypmIyi7WmOr
+        Wu3H/onU48WNYVGMjjqd6XR6OFV3KpGFPMzsoAOmUMWsc0kJCVvVgw/tVVGV
+        ok/k/U71kZZmMH81mFWRS1W0e9hKvVmdc5iiq2xcDNGN1JCvS15Z9KeiS82X
+        MlZnRefzIUGAO9/PTq96Q0jlmwR6Kn2qxN8pGIUiIESsK1bZ/7XXH1MSsGCb
+        uFpsMMgmYE1m14U+BeSVZsgY51SwzdJqmeBHLZNZjo7Bwi91p5U068JXAX11
+        pihnjOAXhdYy8Qtp3WxTpwfK+mgbawcLpeoOLJyLyGNk+aZ6RWaVbF5IYTHh
+        fFOU/R9CSp2cYREKQdmuOVvzPF+ABZHPrftyDGDcqpqkeYiFUUBxTPeI1bKV
+        hWLXiG3wPU+QkYB7ZOwGcnfXoPfjvHCDmribkTAKQxzsUasFtSDYNWrbXdAT
+        cSzCzCNyiwy5wcBhHnHO9nvb63tawFwk2/nets0BPeEWukLNI27XMk+laWSZ
+        FsQxZx4xYySKKfUK2oWFVIEt3W67Ieo/Ggl3zdza5H1lk0x4ZG0ZUwzqypEq
+        pEbXYK1y1eqsefzRmAsWeeMvjCkPY6/0dYcK+uhMGVWmWKUfFkNA/2alOuEM
+        4zDGOzhOeWkF0GklXE3cUuU5pLd65h1b6jMjPc+s8wuXgjcYVkKE2LR31eme
+        EaYiZjs/Vi+ZfcFEnlwSB5x69Mnu0LqglcocnTT0CBCLkHo2AmYs8vmJ4zPY
+        icrRsZw1OTREK2cY3k7CA58n4d2sl+Xo7RcArczgXYVEAz9ms5jvkWhEaot9
+        24FSIbzWGvkwzSwgB4JL4mxRVpmN5SLwbg2MY5/W+ATSJtX6z01y1vuQGamT
+        vU2WxY4gIYnYbsrxE5OUl689kI85pPL+Hw0cEYK5153T3UJXINf80FvazCK/
+        pVw/03fPk+bFZBf/ATx4+AOT4cw5nCgAAA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:19:35 GMT
+recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryInfo_Q183.yml
+++ b/t/fixtures/vcr/CountryInfo_Q183.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q183%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q183%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?country%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -21,11 +21,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 09 Feb 2018 03:41:30 GMT
+      - Wed, 21 Feb 2018 07:17:05 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
-      - '429'
+      - '428'
       Connection:
       - keep-alive
       Server:
@@ -41,41 +41,41 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 174037535, 59591365
+      - 93993446, 252228747
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
       - '0'
       X-Cache:
-      - cp2018 miss, cp2018 miss
+      - cp2018 miss, cp2006 miss
       X-Cache-Status:
       - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=09-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Tue,
-        13 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=09-Feb-2018;Path=/;HttpOnly;secure;Expires=Tue, 13 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 121.44.141.17
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+1Wy26CQBTd+xUTujUyKIq4a5vUjS6abpo0XYxwhYnDQIYB
-        JI3/Xh6WR1GTJthF64q5j7nnzJ3LyXwMEFJcILaCFugjMzIzJiLMzTekWH7E
-        pUiVYbVckQ2w3A78IGJEUp/nFuzBiiSNoWVUyQwcGmbZkYBvZpVSkDh+K6e/
-        3VIL6lUZQO8Z0cMwpy4gjJgMG+w3lNuUO8cTlE5Un6RKLLwyDSB3KZGgyrD2
-        x4RFZcCVMlioapIko4TuqE0kGfnCUYFLKlP1WZtPlOO+w1eBZm/aePn2CrNZ
-        elIUHWOsqa/r1YvlgkfubLCoR1iTWLWZUQmiHatJz7WxOdYx7jJrXkTvrdBn
-        2mTexaxno3dEjKcmPnEB7YnuCW06M7pIxwntG0s3DWzgWRev9Ru2UfceWzDC
-        nQIA+M/HZgnCIzy9cINXgX0COw+ipR+D4F7WAuRv0VkyHfHomc5DxG0IBZGn
-        x+oqmPfcAUbQGsQuK35myK7a/EeXcAsY88Wp5g9KPjc5/U05neqGadzk9Can
-        f0BOJXEusvjnylq+aAeHTxR4C3qPCwAA
+        H4sIAAAAAAAAA+1WS2+CQBC++ys29GpkURTx1japFz00vTRpelhhxI3LQpYF
+        JMb/Xh6WR1GTJnBpPbHzYL5vZ4YvHAcIKTsgtoIW6JgaqRkREWTmB1IsL+RS
+        JMqwPK7IBlhm+54fMiKpxzMLDmCFkkbQMMpkBg4N0uxQwA+zTMlJnJ+l09tu
+        qQXVqQigz5ToaZhRFxCETAY19hvKbcqd8w0KJ6puUibmXpn4kLmUUFBlWPkj
+        wsIisJPSX6hqHMejmO6pTSQZecJRgUsqE/VVm0+U83un7wKN63YOqM+0ybyN
+        WZtHEzKrUMLWq0/yumOMNfV9vXqzduCSBxss6hJW51a+zKgE0YxVvOfa2Bzr
+        GLeZVbvReS8wnpr4wgCaG90R2nRmtJHOG9o1lm4a2MCzNl7jM2yiHly2YIQ7
+        OQDw349wCcIlPLkxwV5gX8DOgmjpRSC4m7YAeVt0lUxLPDqm8xRyGwJB5OW1
+        6gXzkTvACFqD2KfFryxZr81/3hFuAWOeuNT8QcHnL8rpVDdM4y6ndzm9y2mP
+        ciqJc5PFP1fW4o92cPoCujCH4I8LAAA=
     http_version: 
-  recorded_at: Fri, 09 Feb 2018 03:41:30 GMT
+  recorded_at: Wed, 21 Feb 2018 07:17:05 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryInfo_Q191.yml
+++ b/t/fixtures/vcr/CountryInfo_Q191.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q191%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P194%20?legislature%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q191%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?country%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
     body:
       encoding: US-ASCII
       string: ''
@@ -21,17 +21,17 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 08 Feb 2018 03:55:58 GMT
+      - Wed, 21 Feb 2018 07:17:03 GMT
       Content-Type:
       - application/sparql-results+json
       Content-Length:
-      - '408'
+      - '409'
       Connection:
       - keep-alive
       Server:
       - nginx/1.11.6
       X-Served-By:
-      - wdqs2003
+      - wdqs2002
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -41,41 +41,41 @@ http_interactions:
       Vary:
       - Accept, Accept-Encoding
       X-Varnish:
-      - 170593899, 71937478
+      - 212702635, 231585813
       Via:
       - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
       Age:
       - '0'
       X-Cache:
-      - cp2006 miss, cp2018 miss
+      - cp2012 miss, cp2006 miss
       X-Cache-Status:
       - miss
       Strict-Transport-Security:
       - max-age=106384710; includeSubDomains; preload
       Set-Cookie:
-      - WMF-Last-Access-Global=08-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Mon,
-        12 Mar 2018 00:00:00 GMT
-      - WMF-Last-Access=08-Feb-2018;Path=/;HttpOnly;secure;Expires=Mon, 12 Mar 2018
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
         00:00:00 GMT
       X-Analytics:
       - https=1;nocookies=1
       X-Client-Ip:
-      - 121.44.141.17
+      - 121.44.11.137
       Accept-Ranges:
       - bytes
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA7VUy27CMBC88xVWekUEk0IK96pSBVJLL5WqHkxYwgrHjhyb
-        gFD+rLf+WPOgeZS0UqVwsme93pm1xz71CLG2wNYWmZFTClK4ZyrK4BuxPGmE
-        VkerX07nbAU8w6EMDWcapcgQHMAzGvfQAGUyBx+jNNso+AHLlFzEeSyDcrNB
-        D6pZsUDeU6FJP5OuIDJcRzX1KxRrFP65gyJIqk7KxDyqjyFkIcsotPpVfM+4
-        KRa2Wocz247jeBDjDtdMs4FUvg1Coz7az3RKrfO+5LtA/WyafNn2krNe2smL
-        joZDar8u5i/eFgJ2swYPA8brwsrNHDWo5lolmjp0PHHGl8Lq99D1SYyo606n
-        l5yVNTpnvB3R8V0LZdPQXbFN0g6d4SXb2aRd87mOS2nLHTYeYpP0EPAZZ8LP
-        64P4v3HuIy0Fsj8u8Sq0D3IPSgRp50RuiN4CWUJoVhy9DP8q6uIb6VjWEtHH
-        nfRNu8Ouwvn4+aGQLFMzRL857Sq8TwoDIAsUGKVZbceej0nx9/aSL7qpls45
-        BgAA
-    http_version:
-  recorded_at: Thu, 08 Feb 2018 03:55:58 GMT
+        H4sIAAAAAAAAA7VUTW/CMAy98yui7ooooQMG92nSBNLGLpOmHUIxrUWaVGlC
+        Qaj/bLf9sbWF9WPtJk0qp+TZjt+z4+TUI8TygW0sMienFKRwz1SUwTdiudII
+        rY5Wv9gu2Bp4hkMZGs40SpEhOIBrNO6hBopgDh5GabRR8AMWIbmIy1oY5XaL
+        LpS7s4O8p0KTfiZdQWS4jirq1yg2KLxLBWcjKSspAnOrPoaQmSyj0OqX9j3j
+        5uzwtQ7nth3H8SDGHW6YZgOpPBuERn20n+mMWpdzyXeCWrldE47odDqbNTkr
+        91GnzDIUtNXsTp53NBxS+3W5eHF9CNjNBlwMGK9qKw5z1KDqvlI3deh44oyb
+        wsrR6LwVtyM6vmvpRX2gu2KbpK13hk22y5B2zTd1ppS29LP2EOukh4DPORNe
+        nh/E/y/xPtJSIPvjEq9C+yD3oESQVk7klmgfyApCs+boZvhXUY1vpGNZK0QP
+        d9Iz7RN2Fc7Hzw+FZJUOQ/TbpF2F90lhAGSJAqM0qq3t+Zqc/95e8gXHvhLs
+        OQYAAA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:17:03 GMT
 recorded_with: VCR 4.0.0

--- a/t/fixtures/vcr/CountryInfo_Q837.yml
+++ b/t/fixtures/vcr/CountryInfo_Q837.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://query.wikidata.org/sparql?format=json&query=SELECT%20?country%20?countryLabel%20?population%20?executive%20?executiveLabel%20?legislature%20?legislatureLabel%20?head%20?headLabel%20?office%20?officeLabel%20WHERE%0A%7B%0A%20%20BIND(wd:Q837%20AS%20?country)%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1082%20?population%20%7D.%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20?country%20wdt:P194%20?legislature%0A%20%20%20%20MINUS%20%7B%20?legislature%20wdt:P576%20?legislatureEnd%20%7D%0A%20%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P208%20?executive%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P6%20?head%20%7D.%0A%20%20OPTIONAL%20%7B%20?country%20wdt:P1313%20?office%20%7D.%0A%20%20SERVICE%20wikibase:label%20%7B%20bd:serviceParam%20wikibase:language%20%22en%22.%20%7D%0A%7D%0A
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Host:
+      - query.wikidata.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 07:17:06 GMT
+      Content-Type:
+      - application/sparql-results+json
+      Content-Length:
+      - '349'
+      Connection:
+      - keep-alive
+      Server:
+      - nginx/1.11.6
+      X-Served-By:
+      - wdqs2003
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=300
+      Content-Encoding:
+      - gzip
+      Vary:
+      - Accept, Accept-Encoding
+      X-Varnish:
+      - 93874745, 251956796
+      Via:
+      - 1.1 varnish (Varnish/5.1), 1.1 varnish (Varnish/5.1)
+      Age:
+      - '0'
+      X-Cache:
+      - cp2018 miss, cp2006 miss
+      X-Cache-Status:
+      - miss
+      Strict-Transport-Security:
+      - max-age=106384710; includeSubDomains; preload
+      Set-Cookie:
+      - WMF-Last-Access-Global=21-Feb-2018;Path=/;Domain=.wikidata.org;HttpOnly;secure;Expires=Sun,
+        25 Mar 2018 00:00:00 GMT
+      - WMF-Last-Access=21-Feb-2018;Path=/;HttpOnly;secure;Expires=Sun, 25 Mar 2018
+        00:00:00 GMT
+      X-Analytics:
+      - https=1;nocookies=1
+      X-Client-Ip:
+      - 121.44.11.137
+      Accept-Ranges:
+      - bytes
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7VTu27CMBTd+QorXRExpOWRseoIVSuWSlUHk1ySqzpO5NgE
+        hPLvzatOXNqhEkz2ua9zfGyfR4Q4MbDQIT45V6CCBybzGr4TJ0i1UPLkjM12
+        zXbAa5ylmeZMYSpqBEcItMIDWMAUc4gwr6q1hB/QlDQiutUE0/0eA+h3bYJ8
+        VELLcS1dQq65ygfqdyhCFFF3gjZI+pOYwiaqThnUIUdLdMZ9/MC4bhOxUpnv
+        ukVRTAr8xJApNkll5IJQqE7u69JbOF1f+T1g6I3NV7cbzuForxk6o3Tqvm3W
+        2yCGhN2FEGDC+FCYaeaoQNq5XrRHV8v5avFwqcy+6it5cL+gK+pdknW3d206
+        j04pnc/ml4TWG7Vpjwn3ORNRwwDi/54+Q1alfjX0JnzbGCR5ZDELtSRPoHfs
+        L4NvQv8iMQGyQYF5VUXSPbENaNay/Ymj8gspVi3CRwQAAA==
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 07:17:06 GMT
+recorded_with: VCR 4.0.0

--- a/t/query/country_cities.rb
+++ b/t/query/country_cities.rb
@@ -42,8 +42,8 @@ describe Query::CountryCities do
         cities.select { |c| c.id == 'Q65' }.count.must_equal 1
       end
 
-      it 'should have two legislatures' do
-        subject.legislatures.count.must_equal 2
+      it 'should not list an abolished legislature' do
+        subject.legislatures.map(&:id).wont_include 'Q6682043'
       end
     end
   end

--- a/t/query/country_divisions.rb
+++ b/t/query/country_divisions.rb
@@ -43,6 +43,20 @@ describe Query::CountryDivisions do
       end
     end
   end
+
+  describe 'Australia (Q408)' do
+    around { |test| VCR.use_cassette('CountryDivisions Q408', &test) }
+
+    let(:divisions) { Query::CountryDivisions.new(id: 'Q408').data }
+
+    describe 'Norfolk Island (Q31057)' do
+      subject { divisions.find { |c| c.id == 'Q31057' } }
+
+      it 'should not list an abolished legislature' do
+        subject.legislatures.map(&:id).wont_include 'Q7051064'
+      end
+    end
+  end
 end
 
 describe Query::CountryDivisions do

--- a/t/query/country_info.rb
+++ b/t/query/country_info.rb
@@ -39,4 +39,14 @@ describe Query::CountryInfo do
       subject.legislatures.count.must_equal 2
     end
   end
+
+  describe 'Nepal (Q837)' do
+    around { |test| VCR.use_cassette('CountryInfo Q837', &test) }
+
+    subject { Query::CountryInfo.new(id: 'Q837').data }
+
+    it 'should not show an abolished legislature' do
+      subject.legislatures.map(&:id).wont_include 'Q16057514'
+    end
+  end
 end


### PR DESCRIPTION
# What does this do?

Removes legislatures that have a P576 abolished statement from being displayed in the application.

# Why was this needed?

Legislatures marked as abolished were being displayed in the application like they were a current claim.

In the case of Los Angeles this meant a legislature that was abolished in 1889 was being listed. We don't want that in the Wikidata we'll eventually use so it's not useful here.

In Nepal's case a legislature that was marked abolished is currently listed when it should actually be the one that's replaced it. The change in this PR would prompt a researcher to update Wikidata.

In Norfolk Island's case the legislature has been abolished and there's not going to be a new one to replace it. We're now going to be showing this as "unknown" when that's not really the case. This could be an argument for showing abolished legislatures but noting they're abolished?

# Relevant Issue(s)

Fixes #20.

# Screenshots

[Before](https://github.com/everypolitician/legislative-explorer/issues/20#user-content-screenshots).

After:

Nepal's country legislature:

![screenshot from 2018-02-22 10-49-18](https://user-images.githubusercontent.com/48945/36512347-229d178c-17be-11e8-9122-6b0bb208e942.png)

Australia FLACS legislature:
![screenshot from 2018-02-22 10-49-32](https://user-images.githubusercontent.com/48945/36512348-22f961a4-17be-11e8-961f-7e8e438d86a8.png)

USA city legislature:
![screenshot from 2018-02-22 10-49-45](https://user-images.githubusercontent.com/48945/36512349-233c730e-17be-11e8-8165-f2a43424e28a.png)
