### PR TITLE
Updated application name in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name":"viewer-sinatra",
+  "name":"legislative-explorer",
   "scripts":{},
   "env":{
     "LANG":{


### PR DESCRIPTION
# What does this do?

The "name" field in app.json was "viewer-sinatra" reflecting the
heritage of this code. This commit simply updates this.

# Why was this needed?

This file is needed by Heroku Pipelines to enable review apps.

