### PR TITLE
Add reek to default rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 RuboCop::RakeTask.new
 
 Reek::Rake::Task.new do |t|
-  t.source_files = FileList['**/*.rb']
+  t.source_files = FileList['**/*.rb'].exclude('vendor/**/*.rb')
   t.verbose = false
   t.fail_on_error = true
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,4 +24,4 @@ end
 require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
-task default: ['test', 'rubocop', 'bundle:audit']
+task default: ['test', 'rubocop', 'reek', 'bundle:audit']


### PR DESCRIPTION
We shouldn't simply blindly rewrite code simply to keep 'reek' happy: we
can always override on a case by case basis where we think it's taking
us down the wrong path, or where we simply need to get something through
as a quick hack.

But its complaints/suggestions are generally a pretty good indication
that something is off in a way that will make code harder to maintain /
extend / come back to later, etc, so let's make it part of the default
`rake` task list (and thus checked by travis)

Closes #33