### PR TITLE
remove HTMLHelper

### DIFF
--- a/.config.reek
+++ b/.config.reek
@@ -1,9 +1,6 @@
 ---
 IrresponsibleModule:
   enabled: false
-UtilityFunction:
-  exclude:
-  - HTMLHelper#unescape_uri
 FeatureEnvy:
   exclude:
   - Query::CountryDivisions#legislatures # TODO: fix this later

--- a/app.rb
+++ b/app.rb
@@ -16,7 +16,6 @@ class Integer
 end
 
 Dotenv.load
-helpers HTMLHelper
 
 set :erb, trim: '-'
 

--- a/lib/html_helper.rb
+++ b/lib/html_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module HTMLHelper
-  def unescape_uri(text)
-    CGI.unescape(text)
-  end
-end


### PR DESCRIPTION
This was inherited from viewer-sinatra and isn't used here. If we want it
back, we should really be using objects to represent the URIs anyway,
rather than treating them as strings.